### PR TITLE
Better subtitles

### DIFF
--- a/audioware/reds/Compat.reds
+++ b/audioware/reds/Compat.reds
@@ -72,6 +72,7 @@ private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName:
       line.text = subtitle;
       line.type = scnDialogLineType.Regular;
       board.SetVariant(GetAllBlackboardDefs().UIGameData.ShowDialogLine, ToVariant([line]), true);
+      Audioware.GetInstance(game).m_subtitleLine = line;
       let callback: ref<HideSubtitleCallback> = new HideSubtitleCallback();
       callback.line = line;
       Audioware.GetInstance(game).m_subtitleDelayID = GameInstance
@@ -79,4 +80,26 @@ private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName:
       .DelayCallback(callback, duration);
     }
   }
+}
+
+private func PauseHideSubtitleCallback() -> Void {
+    let game = GetGameInstance();
+    let delay = Audioware.GetInstance(game).m_subtitleDelayID;
+    if NotEquals(delay, GetInvalidDelayID()) {
+        Audioware.GetInstance(game).m_subtitleRemaining = GameInstance.GetDelaySystem(game).GetRemainingDelayTime(delay);
+        GameInstance.GetDelaySystem(game).CancelCallback(delay);
+    }
+}
+
+private func ResumeHideSubtitleCallback() -> Void {
+    let game = GetGameInstance();
+    let remaining = Audioware.GetInstance(game).m_subtitleRemaining;
+    let line = Audioware.GetInstance(game).m_subtitleLine;
+    if remaining >= 0.3 {
+        let callback: ref<HideSubtitleCallback> = new HideSubtitleCallback();
+        callback.line = line;
+        Audioware.GetInstance(game).m_subtitleDelayID = GameInstance
+        .GetDelaySystem(game)
+        .DelayCallback(callback, remaining);
+    }
 }

--- a/audioware/src/engine/mod.rs
+++ b/audioware/src/engine/mod.rs
@@ -28,10 +28,14 @@ pub fn update_state(state: State) {
     let previous = state::update(state);
     match (previous, state) {
         (State::InGame, State::InMenu) | (State::InGame, State::InPause) => {
+            red4ext_rs::info!("switch state from {previous:#?} to {state:#?}");
             sounds::pause();
+            crate::natives::pause_hide_subtitle_callback();
         }
         (State::InMenu, State::InGame) | (State::InPause, State::InGame) => {
+            red4ext_rs::info!("switch state from {previous:#?} to {state:#?}");
             sounds::resume();
+            crate::natives::resume_hide_subtitle_callback();
         }
         _ => {}
     };

--- a/audioware/src/natives.rs
+++ b/audioware/src/natives.rs
@@ -50,6 +50,12 @@ pub fn supported_engine_languages() -> Vec<CName> {
 #[redscript_global(name = "Audioware.PropagateSubtitle")]
 pub fn propagate_subtitle(reaction: CName, entity_id: EntityId, emitter_name: CName) -> ();
 
+#[redscript_global(name = "Audioware.PauseHideSubtitleCallback")]
+pub fn pause_hide_subtitle_callback() -> ();
+
+#[redscript_global(name = "Audioware.ResumeHideSubtitleCallback")]
+pub fn resume_hide_subtitle_callback() -> ();
+
 /// get reaction duration (in seconds) from sound, or return default
 pub fn get_reaction_duration(sound: CName) -> f32 {
     let gender = crate::engine::localization::gender().unwrap_or_default();


### PR DESCRIPTION
- [x] callback in charge of hiding subtitle should be paused/resumed when interacting with menu, in pause, on death menu, etc.
- [ ] previous concept must be applied to any kind of subtitle for any entity.
- [ ] chatters subtitles (or nameplates) should also be handled too.

Reminder:
- show subtitle:
  `GetAllBlackboardDefs().UIGameData` => `GetAllBlackboardDefs().UIGameData.ShowDialogLine` (`line: scnDialogLineData`)
- hide subtitle:
  `GetAllBlackboardDefs().UIGameData` => `GetAllBlackboardDefs().UIGameData.HideDialogLine` (`id: CRUID` from `line: scnDialogLineData`)
- use `CRUID` from `reaction: CName` as `Uint64`