### PR TITLE
Support EQ preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently in its infancy, further information will be provided at a later time.
 - [x] seamlessly integrates with vanilla `AudioSystem`, but currently restricted to:
       - `Play`
       - `Stop`
+      - `Switch`
+- [x] update reverb via blackboard
 
 ### dependent features
 

--- a/audioware/reds/AudioSystemExt.reds
+++ b/audioware/reds/AudioSystemExt.reds
@@ -1,0 +1,8 @@
+module Audioware
+
+private native func PlayOverThePhone(eventName: CName, emitterName: CName) -> Void;
+
+@addMethod(AudioSystem)
+public func PlayOverThePhone(eventName: CName, emitterName: CName) -> Void {
+    PlayOverThePhone(eventName, emitterName);
+}

--- a/audioware/reds/Compat.reds
+++ b/audioware/reds/Compat.reds
@@ -46,7 +46,7 @@ public class LocalizationPackage extends ModLocalizationPackage {
     }
 }
 
-private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName: CName) -> Void {
+private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName: CName, lineType: scnDialogLineType) -> Void {
   if !IsNameValid(reaction) { return; }
   let game = GetGameInstance();
   let target = GameInstance.FindEntityByID(game, entityID);
@@ -64,7 +64,7 @@ private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName:
       line.speaker = target as GameObject;
       line.speakerName = NameToString(emitterName);
       line.text = subtitle;
-      line.type = scnDialogLineType.Regular;
+      line.type = lineType;
       board.SetVariant(GetAllBlackboardDefs().UIGameData.ShowDialogLine, ToVariant([line]), true);
       let callback: ref<HideSubtitleCallback> = new HideSubtitleCallback();
       callback.line = line;

--- a/audioware/reds/Debug.reds
+++ b/audioware/reds/Debug.reds
@@ -71,6 +71,13 @@ public static exec func TestUpdatePlayerPreset(gi: GameInstance, value: Int32) -
     board.SetInt(defs.AudiowareSettings.PlayerPreset, value, true);
 }
 
+// Game.TestPlayOverThePhone("nah_everything_is_all_good", "V");
+public static exec func TestPlayOverThePhone(gi: GameInstance, name: String, emitter: String) -> Void {
+    let sound: CName = StringToName(name);
+    let speaker: CName = StringToName(emitter);
+    GameInstance.GetAudioSystem(gi).PlayOverThePhone(sound, speaker);
+}
+
 // Game.ApplyVentriloquistOnNPC();
 public static exec func ApplyVentriloquistOnNPC(gi: GameInstance) -> Void {
   let player: ref<PlayerPuppet> = GetPlayer(gi);

--- a/audioware/reds/Debug.reds
+++ b/audioware/reds/Debug.reds
@@ -62,6 +62,15 @@ public static exec func TestUpdateReverb(gi: GameInstance, value: Float) -> Void
     board.SetFloat(defs.AudiowareSettings.PlayerReverb, value, true);
 }
 
+// Game.TestUpdatePlayerPreset(0); // 0, 1 or 2
+public static exec func TestUpdatePlayerPreset(gi: GameInstance, value: Int32) -> Void {
+    let defs = GetAllBlackboardDefs();
+    let boards = GameInstance.GetBlackboardSystem(gi);
+    let board = boards.Get(defs.AudiowareSettings);
+    LogChannel(n"DEBUG", s"board exists? \(ToString(IsDefined(board)))");
+    board.SetInt(defs.AudiowareSettings.PlayerPreset, value, true);
+}
+
 // Game.ApplyVentriloquistOnNPC();
 public static exec func ApplyVentriloquistOnNPC(gi: GameInstance) -> Void {
   let player: ref<PlayerPuppet> = GetPlayer(gi);

--- a/audioware/reds/Settings.reds
+++ b/audioware/reds/Settings.reds
@@ -1,12 +1,20 @@
 module Audioware
 
+enum Preset {
+    None = 0,
+    Underwater = 1,
+    OnThePhone = 2,
+}
+
 public class AudiowareSettingsDef extends BlackboardDefinition {
     public let PlayerReverb: BlackboardID_Float;
+    public let PlayerPreset: BlackboardID_Int;
     public final const func AutoCreateInSystem() -> Bool {
         return true;
     }
     public final const func Initialize(blackboard: ref<IBlackboard>) -> Void {
         blackboard.SetFloat(this.PlayerReverb, 0.);
+        blackboard.SetInt(this.PlayerPreset, EnumInt(Preset.None));
     }
 }
 

--- a/audioware/reds/System.reds
+++ b/audioware/reds/System.reds
@@ -5,6 +5,7 @@ private native func UnregisterEmitter(id: EntityID) -> Void;
 private native func UpdateActorLocation(id: EntityID, position: Vector4, orientation: Quaternion) -> Void;
 private native func EmittersCount() -> Int32;
 private native func UpdatePlayerReverb(value: Float) -> Bool;
+private native func UpdatePlayerPreset(preset: Preset) -> Bool;
 
 public class Audioware extends ScriptableSystem {
     private let m_callbackSystem: wref<CallbackSystem>;
@@ -13,6 +14,7 @@ public class Audioware extends ScriptableSystem {
     public let m_positionsDelayID: DelayID;
     private let m_emitters: array<EntityID>;
     private let m_playerReverbListener: ref<CallbackHandle>;
+    private let m_playerPresetListener: ref<CallbackHandle>;
 
     public func RegisterVentriloquist(id: EntityID) -> Void {
         // LogChannel(n"DEBUG", s"register ventriloquist (\(EntityID.ToDebugString(id)))");
@@ -78,6 +80,7 @@ public class Audioware extends ScriptableSystem {
             boards = GameInstance.GetBlackboardSystem(this.GetGameInstance());
             board = boards.Get(defs.AudiowareSettings);
             this.m_playerReverbListener = board.RegisterListenerFloat(defs.AudiowareSettings.PlayerReverb, this, n"OnReverbChanged", false);
+            this.m_playerPresetListener = board.RegisterListenerInt(defs.AudiowareSettings.PlayerPreset, this, n"OnPlayerPresetChanged", false);
         }
     }
 
@@ -94,6 +97,7 @@ public class Audioware extends ScriptableSystem {
             boards = GameInstance.GetBlackboardSystem(this.GetGameInstance());
             board = boards.Get(defs.AudiowareSettings);
             board.UnregisterListenerFloat(defs.AudiowareSettings.PlayerReverb, this.m_playerReverbListener);
+            board.UnregisterListenerInt(defs.AudiowareSettings.PlayerPreset, this.m_playerPresetListener);
         }
     }
 
@@ -112,6 +116,11 @@ public class Audioware extends ScriptableSystem {
     }
     protected cb func OnReverbChanged(value: Float) -> Bool {
         let result = UpdatePlayerReverb(value);
+        return result;
+    }
+    protected cb func OnPlayerPresetChanged(value: Int32) -> Bool {
+        let preset: Preset = IntEnum<Preset>(value);
+        let result = UpdatePlayerPreset(preset);
         return result;
     }
 

--- a/audioware/src/engine/effects.rs
+++ b/audioware/src/engine/effects.rs
@@ -1,0 +1,96 @@
+use kira::{track::effect::eq_filter::EqFilterHandle, CommandError};
+use red4ext_rs::conv::NativeRepr;
+
+/// suppress high frequences (from 20k to x)
+pub const EQ_LOW_PASS_DEFAULT_FREQUENCES: f64 = 20_000.;
+/// suppress low frequences (from 0 to x)
+pub const EQ_HIGH_PASS_DEFAULT_FREQUENCES: f64 = 0.;
+pub const EQ_DEFAULT_GAIN: f64 = 0.;
+pub const EQ_DEFAULT_Q: f64 = 0.;
+
+pub struct EQ {
+    pub lowpass: LowPass,
+    pub highpass: HighPass,
+}
+
+pub struct LowPass(pub EqFilterHandle);
+pub struct HighPass(pub EqFilterHandle);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[repr(i64)]
+pub enum Preset {
+    #[default]
+    None = 0,
+    Underwater = 1,
+    OnThePhone = 2,
+}
+
+impl std::fmt::Display for Preset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "no preset"),
+            Self::Underwater => write!(f, "underwater preset"),
+            Self::OnThePhone => write!(f, "holocall preset"),
+        }
+    }
+}
+
+unsafe impl NativeRepr for Preset {
+    const NAME: &'static str = "Audioware.Preset";
+}
+
+pub trait EqPass {
+    fn preset(&mut self, preset: Preset) -> Result<(), CommandError>;
+}
+
+impl EqPass for LowPass {
+    fn preset(&mut self, preset: Preset) -> Result<(), CommandError> {
+        match preset {
+            Preset::None => {
+                self.0
+                    .set_frequency(EQ_LOW_PASS_DEFAULT_FREQUENCES, Default::default())?;
+                self.0.set_gain(EQ_DEFAULT_GAIN, Default::default())?;
+                self.0.set_q(EQ_DEFAULT_Q, Default::default())?;
+            }
+            Preset::OnThePhone => {
+                self.0.set_frequency(5000., Default::default())?;
+                self.0.set_gain(6., Default::default())?;
+                self.0.set_q(2., Default::default())?;
+            }
+            Preset::Underwater => {
+                self.0.set_frequency(1_000., Default::default())?;
+                self.0.set_gain(0., Default::default())?;
+                self.0.set_q(0., Default::default())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl EqPass for HighPass {
+    fn preset(&mut self, preset: Preset) -> Result<(), CommandError> {
+        match preset {
+            Preset::None | Preset::Underwater => {
+                self.0
+                    .set_frequency(EQ_HIGH_PASS_DEFAULT_FREQUENCES, Default::default())?;
+                self.0.set_gain(EQ_DEFAULT_GAIN, Default::default())?;
+                self.0.set_q(EQ_DEFAULT_Q, Default::default())?;
+            }
+            Preset::OnThePhone => {
+                self.0.set_frequency(500., Default::default())?;
+                self.0.set_gain(6., Default::default())?;
+                self.0.set_q(2., Default::default())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl EqPass for EQ {
+    fn preset(&mut self, preset: Preset) -> Result<(), CommandError> {
+        self.lowpass.preset(preset)?;
+        self.highpass.preset(preset)?;
+        red4ext_rs::info!("updated preset successfully to {preset}");
+        Ok(())
+    }
+}

--- a/audioware/src/engine/effects.rs
+++ b/audioware/src/engine/effects.rs
@@ -8,6 +8,15 @@ pub const EQ_HIGH_PASS_DEFAULT_FREQUENCES: f64 = 0.;
 pub const EQ_DEFAULT_GAIN: f64 = 0.;
 pub const EQ_DEFAULT_Q: f64 = 0.;
 
+pub const EQ_LOW_PASS_PHONE_FREQUENCES: f64 = 5000.;
+pub const EQ_HIGH_PASS_PHONE_FREQUENCES: f64 = 500.;
+pub const EQ_PHONE_GAIN: f64 = 6.;
+pub const EQ_PHONE_Q: f64 = 2.;
+
+pub const EQ_LOW_PASS_UNDERWATER_FREQUENCES: f64 = 1_000.;
+pub const EQ_UNDERWATER_GAIN: f64 = EQ_DEFAULT_GAIN;
+pub const EQ_UNDERWATER_Q: f64 = EQ_DEFAULT_Q;
+
 pub struct EQ {
     pub lowpass: LowPass,
     pub highpass: HighPass,
@@ -53,14 +62,16 @@ impl EqPass for LowPass {
                 self.0.set_q(EQ_DEFAULT_Q, Default::default())?;
             }
             Preset::OnThePhone => {
-                self.0.set_frequency(5000., Default::default())?;
-                self.0.set_gain(6., Default::default())?;
-                self.0.set_q(2., Default::default())?;
+                self.0
+                    .set_frequency(EQ_LOW_PASS_PHONE_FREQUENCES, Default::default())?;
+                self.0.set_gain(EQ_PHONE_GAIN, Default::default())?;
+                self.0.set_q(EQ_PHONE_Q, Default::default())?;
             }
             Preset::Underwater => {
-                self.0.set_frequency(1_000., Default::default())?;
-                self.0.set_gain(0., Default::default())?;
-                self.0.set_q(0., Default::default())?;
+                self.0
+                    .set_frequency(EQ_LOW_PASS_UNDERWATER_FREQUENCES, Default::default())?;
+                self.0.set_gain(EQ_UNDERWATER_GAIN, Default::default())?;
+                self.0.set_q(EQ_UNDERWATER_Q, Default::default())?;
             }
         }
         Ok(())
@@ -77,9 +88,10 @@ impl EqPass for HighPass {
                 self.0.set_q(EQ_DEFAULT_Q, Default::default())?;
             }
             Preset::OnThePhone => {
-                self.0.set_frequency(500., Default::default())?;
-                self.0.set_gain(6., Default::default())?;
-                self.0.set_q(2., Default::default())?;
+                self.0
+                    .set_frequency(EQ_HIGH_PASS_PHONE_FREQUENCES, Default::default())?;
+                self.0.set_gain(EQ_PHONE_GAIN, Default::default())?;
+                self.0.set_q(EQ_PHONE_Q, Default::default())?;
             }
         }
         Ok(())

--- a/audioware/src/engine/mod.rs
+++ b/audioware/src/engine/mod.rs
@@ -1,9 +1,10 @@
 use crate::natives::propagate_subtitle;
 
-use self::sounds::SoundInfos;
 pub use self::state::State;
+use self::{effects::Preset, sounds::SoundInfos};
 
 pub mod banks;
+pub mod effects;
 pub mod localization;
 pub mod manager;
 pub mod sounds;
@@ -129,4 +130,11 @@ pub fn update_actor_location(id: EntityId, position: Vector4, orientation: Quate
     } else {
         tracks::update_emitter(id, position);
     }
+}
+
+pub fn update_player_preset(preset: Preset) -> anyhow::Result<()> {
+    if let Ok(()) = crate::engine::state::update_player_preset(preset) {
+        crate::engine::tracks::update_player_preset(preset)?;
+    }
+    anyhow::bail!("unable to update player preset")
 }

--- a/audioware/src/engine/mod.rs
+++ b/audioware/src/engine/mod.rs
@@ -11,7 +11,7 @@ pub mod sounds;
 pub mod state;
 pub mod tracks;
 
-use audioware_sys::interop::{quaternion::Quaternion, vector4::Vector4};
+use audioware_sys::interop::{audio::ScnDialogLineType, quaternion::Quaternion, vector4::Vector4};
 use kira::tween::Tween;
 use red4ext_rs::types::{CName, EntityId};
 
@@ -37,12 +37,19 @@ pub fn update_state(state: State) {
 }
 
 /// play sound
-pub fn play(sound_name: CName, entity_id: Option<EntityId>, emitter_name: Option<CName>) {
+pub fn play(
+    sound_name: CName,
+    entity_id: Option<EntityId>,
+    emitter_name: Option<CName>,
+    line_type: Option<ScnDialogLineType>,
+) {
     if let Some(mut manager) = manager::try_get_mut() {
         if let Ok(mut data) = banks::data(&sound_name) {
-            if let Some(destination) =
-                tracks::output_destination(entity_id.clone(), emitter_name.clone())
-            {
+            if let Some(destination) = tracks::output_destination(
+                entity_id.clone(),
+                emitter_name.clone(),
+                line_type == Some(ScnDialogLineType::Holocall),
+            ) {
                 data.settings.output_destination = destination;
                 if let Ok(handle) = manager.play(data) {
                     sounds::store(
@@ -51,8 +58,23 @@ pub fn play(sound_name: CName, entity_id: Option<EntityId>, emitter_name: Option
                         entity_id.clone(),
                         emitter_name.clone(),
                     );
-                    if let (Some(entity_id), Some(emitter_name)) = (entity_id, emitter_name) {
-                        propagate_subtitle(sound_name, entity_id, emitter_name);
+                    if let (Some(entity_id), Some(emitter_name)) = (entity_id, emitter_name.clone())
+                    {
+                        propagate_subtitle(
+                            sound_name,
+                            entity_id,
+                            emitter_name,
+                            line_type.unwrap_or(ScnDialogLineType::Regular),
+                        );
+                    } else if let (Some(emitter_name), Some(ScnDialogLineType::Holocall)) =
+                        (emitter_name, line_type)
+                    {
+                        propagate_subtitle(
+                            sound_name,
+                            EntityId::from(0),
+                            emitter_name,
+                            line_type.unwrap(),
+                        );
                     }
                 } else {
                     red4ext_rs::error!("error playing sound {sound_name}");

--- a/audioware/src/hook.rs
+++ b/audioware/src/hook.rs
@@ -46,7 +46,7 @@ pub fn custom_engine_play(params: (CName, EntityId, CName)) {
     } else {
         Some(emitter_name)
     };
-    crate::engine::play(event_name, entity_id, emitter_name);
+    crate::engine::play(event_name, entity_id, emitter_name, None);
 }
 
 pub fn custom_engine_stop(params: (CName, EntityId, CName)) {

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -74,6 +74,10 @@ impl Plugin for Audioware {
             "Audioware.UpdatePlayerReverb",
             crate::natives::update_player_reverb
         );
+        register_function!(
+            "Audioware.UpdatePlayerPreset",
+            crate::natives::update_player_preset
+        );
     }
 
     fn post_register() {

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -78,6 +78,10 @@ impl Plugin for Audioware {
             "Audioware.UpdatePlayerPreset",
             crate::natives::update_player_preset
         );
+        register_function!(
+            "Audioware.PlayOverThePhone",
+            crate::natives::play_over_the_phone
+        );
     }
 
     fn post_register() {

--- a/audioware/src/natives.rs
+++ b/audioware/src/natives.rs
@@ -9,6 +9,7 @@ use red4ext_rs::types::Ref;
 use audioware_sys::interop::gender::PlayerGender;
 use audioware_sys::interop::localization::LocalizationPackage;
 
+use crate::engine::effects::Preset;
 use crate::engine::State;
 use crate::types::voice::Subtitle;
 
@@ -74,4 +75,20 @@ pub fn emitters_count() -> i32 {
 
 pub fn update_player_reverb(value: f32) -> bool {
     crate::engine::tracks::update_player_reverb(value)
+}
+
+pub fn update_player_preset(preset: Preset) -> bool {
+    match crate::engine::state::update_player_preset(preset) {
+        Err(e) => {
+            red4ext_rs::warn!("{e}");
+            false
+        }
+        _ => match crate::engine::tracks::update_player_preset(preset) {
+            Err(e) => {
+                red4ext_rs::warn!("{e}");
+                false
+            }
+            _ => true,
+        },
+    }
 }

--- a/audioware/src/natives.rs
+++ b/audioware/src/natives.rs
@@ -1,3 +1,4 @@
+use audioware_sys::interop::audio::ScnDialogLineType;
 use audioware_sys::interop::locale::Locale;
 use audioware_sys::interop::quaternion::Quaternion;
 use audioware_sys::interop::vector4::Vector4;
@@ -49,7 +50,12 @@ pub fn supported_engine_languages() -> Vec<CName> {
 }
 
 #[redscript_global(name = "Audioware.PropagateSubtitle")]
-pub fn propagate_subtitle(reaction: CName, entity_id: EntityId, emitter_name: CName) -> ();
+pub fn propagate_subtitle(
+    reaction: CName,
+    entity_id: EntityId,
+    emitter_name: CName,
+    scene_dialog_line_type: ScnDialogLineType,
+) -> ();
 
 /// get reaction duration (in seconds) from sound, or return default
 pub fn get_reaction_duration(sound: CName) -> f32 {
@@ -91,4 +97,13 @@ pub fn update_player_preset(preset: Preset) -> bool {
             _ => true,
         },
     }
+}
+
+pub fn play_over_the_phone(event_name: CName, emitter_name: CName) {
+    crate::engine::play(
+        event_name,
+        None,
+        Some(emitter_name),
+        Some(ScnDialogLineType::Holocall),
+    );
 }

--- a/sys/src/interop/audio.rs
+++ b/sys/src/interop/audio.rs
@@ -1,5 +1,5 @@
 use audioware_macros::FromMemory;
-use red4ext_rs::types::CName;
+use red4ext_rs::{conv::NativeRepr, types::CName};
 
 use super::iscriptable::ISCRIPTABLE_SIZE;
 
@@ -49,4 +49,27 @@ pub struct AudioEvent {
     pub event_type: AudioEventActionType,
     pub event_flags: AudioAudioEventFlags,
     unk64: i32,
+}
+
+/// see [RED4ext::scn::DialogLineType](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/Generated/scn/DialogLineType.hpp).
+#[derive(Debug, Clone, Copy, strum_macros::Display, strum_macros::FromRepr, PartialEq)]
+#[repr(u32)]
+pub enum ScnDialogLineType {
+    None = 0,
+    Regular = 1,
+    Holocall = 2,
+    SceneComment = 3,
+    OverHead = 4,
+    Radio = 5,
+    GlobalTV = 6,
+    Invisible = 7,
+    OverHeadAlwaysVisible = 9,
+    OwnerlessRegular = 10,
+    AlwaysCinematicNoSpeaker = 11,
+    GlobalTVAlwaysVisible = 12,
+    Narrator = 13,
+}
+
+unsafe impl NativeRepr for ScnDialogLineType {
+    const NAME: &'static str = "scnDialogLineType";
 }


### PR DESCRIPTION
Add basic track associated EQ preset.

- [x] player main track EQ preset possible values: `None`, `Underwater`, `OnThePhone`
- [x] expose preset as blackboard
- [x] create an additional track dedicated to NPC over the phone
- [x] expose a convenience method to make a NPC talk over the phone