### PR TITLE
Add checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
         run: just ci 'Audioware-windows-latest-${{ github.ref_name }}'
       - name: Optimize binary size
         run: just optimize 'Audioware-windows-latest-${{ github.ref_name }}'
+      - name: Generate binary checksum
+        uses: jmgilman/actions-generate-checksum@v1
+        with:
+          patterns: Audioware-windows-latest-${{ github.ref_name }}/red4ext/plugins/audioware/audioware.dll
+          method: sha256
+          output: Audioware-windows-latest-${{ github.ref_name }}/red4ext/plugins/audioware/checksum.txt
       - name: Zip files
         uses: thedoctor0/zip-release@0.7.6
         with:

--- a/justfile
+++ b/justfile
@@ -109,3 +109,6 @@ alias c := check
 # TODO: finish updating all patterns
 offsets:
   {{zoltan_exe}} '.\addresses.hpp' '{{ join(game_dir, "bin", "x64", "Cyberpunk2077.exe") }}' -f 'std=c++23' --rust-output '.\addresses.rs'
+
+checksum TO:
+  Get-FileHash -Path "{{TO}}" -Algorithm SHA256 | Select-Object -ExpandProperty Hash


### PR DESCRIPTION
[Kpblcep](https://www.nexusmods.com/cyberpunk2077/users/1912320) reported a concern about a potential threat on Nexus Audioware's posts, so this PR will pack a `checksum.txt` alongside binary in CI, if users want to verify binary hasn't been forged.