### PR TITLE
Fix flatlines on exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,16 @@ audioware-macros = { path = "macros" }
 audioware-mem = { path = "mem" }
 audioware-sys = { path = "sys" }
 cxx = "1"
-fixed-map = { version = "0.9.4", features = ["serde"] }
+fixed-map = { version = "0.9.5", features = ["serde"] }
 glam = { version = "0.27.0", features = ["mint"] }
 kira = "0.8.7"
 lazy_static = "1.4.0"
-memoffset = "0.9.0"
+memoffset = "0.9.1"
 mint = "0.5.9"
 red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs.git", rev = "8e938fa", features = ["macros"] }
+# red4ext-rs = { path = "../red4ext-rs/red4ext", features = ["macros"] }
 retour = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
-strum = "0.26"
-strum_macros = "0.26"
+strum = "0.26.2"
+strum_macros = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ lazy_static = "1.4.0"
 memoffset = "0.9.1"
 mint = "0.5.9"
 red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs.git", rev = "8e938fa", features = ["macros"] }
-# red4ext-rs = { path = "../red4ext-rs/red4ext", features = ["macros"] }
 retour = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"

--- a/audioware/Cargo.toml
+++ b/audioware/Cargo.toml
@@ -27,8 +27,8 @@ serde.workspace = true
 serde_yaml = "0.9"
 strum.workspace = true
 strum_macros.workspace = true
-ulid = "1.1.0"
-validator = { version = "0.16", features = ["derive"] }
+ulid = "1.1.2"
+validator = { version = "0.18.1", features = ["derive"] }
 
 [package.metadata.cargo-machete]
 ignored = ["memoffset", "retour", "strum", "strum_macros"]

--- a/audioware/reds/Compat.reds
+++ b/audioware/reds/Compat.reds
@@ -25,7 +25,6 @@ public class LocalizationProvider extends ModLocalizationProvider {
         let supported = ArrayContains(languages, language);
         if supported {
             let package = new LocalizationPackage();
-            package.system = LocalizationSystem.GetInstance(this.GetGameInstance());
             return package;
         }
         return null;
@@ -34,12 +33,11 @@ public class LocalizationProvider extends ModLocalizationProvider {
 }
 
 public class LocalizationPackage extends ModLocalizationPackage {
-    private let system: ref<LocalizationSystem>;
     public func VoiceLanguage() -> CName {
-        return this.system.GetVoiceLanguage();
+        return LocalizationSystem.GetInstance(GetGameInstance()).GetVoiceLanguage();
     }
     public func SubtitleLanguage() -> CName {
-        return this.system.GetSubtitleLanguage();
+        return LocalizationSystem.GetInstance(GetGameInstance()).GetSubtitleLanguage();
     }
     protected func DefineSubtitles() -> Void {
         DefineEngineSubtitles(this);

--- a/audioware/reds/Natives.reds
+++ b/audioware/reds/Natives.reds
@@ -9,6 +9,7 @@ enum EngineState {
     InPause = 5,
     End = 6,
     Unload = 7,
+    Unreachable = 8, // special state to indicate internal error: should not be set from .reds
 }
 
 private native func UpdateEngineState(state: EngineState) -> Void;

--- a/audioware/reds/Settings.reds
+++ b/audioware/reds/Settings.reds
@@ -12,9 +12,11 @@ public class AudiowareSettingsDef extends BlackboardDefinition {
     public final const func AutoCreateInSystem() -> Bool {
         return true;
     }
-    public final const func Initialize(blackboard: ref<IBlackboard>) -> Void {
-        blackboard.SetFloat(this.PlayerReverb, 0.);
-        blackboard.SetInt(this.PlayerPreset, EnumInt(Preset.None));
+    public final const func Initialize(blackboard: wref<IBlackboard>) -> Void {
+        if IsDefined(blackboard) {
+            blackboard.SetFloat(this.PlayerReverb, 0.);
+            blackboard.SetInt(this.PlayerPreset, EnumInt(Preset.None));
+        } else { F("blackboard should not be undefined", "AudiowareSettingsDef.Initialize"); }
     }
 }
 

--- a/audioware/reds/System.reds
+++ b/audioware/reds/System.reds
@@ -13,8 +13,8 @@ public class Audioware extends ScriptableSystem {
     public let m_positionDelayID: DelayID;
     public let m_positionsDelayID: DelayID;
     private let m_emitters: array<EntityID>;
-    private let m_playerReverbListener: ref<CallbackHandle>;
-    private let m_playerPresetListener: ref<CallbackHandle>;
+    private let m_playerReverbListener: wref<CallbackHandle>;
+    private let m_playerPresetListener: wref<CallbackHandle>;
 
     public func RegisterVentriloquist(id: EntityID) -> Void {
         // LogChannel(n"DEBUG", s"register ventriloquist (\(EntityID.ToDebugString(id)))");
@@ -96,8 +96,12 @@ public class Audioware extends ScriptableSystem {
             this.m_positionDelayID = GetInvalidDelayID();
             boards = GameInstance.GetBlackboardSystem(this.GetGameInstance());
             board = boards.Get(defs.AudiowareSettings);
-            board.UnregisterListenerFloat(defs.AudiowareSettings.PlayerReverb, this.m_playerReverbListener);
-            board.UnregisterListenerInt(defs.AudiowareSettings.PlayerPreset, this.m_playerPresetListener);
+            if IsDefined(this.m_playerReverbListener) {
+                board.UnregisterListenerFloat(defs.AudiowareSettings.PlayerReverb, this.m_playerReverbListener);
+            }
+            if IsDefined(this.m_playerPresetListener) {
+                board.UnregisterListenerInt(defs.AudiowareSettings.PlayerPreset, this.m_playerPresetListener);
+            }
         }
     }
 

--- a/audioware/reds/Utils.reds
+++ b/audioware/reds/Utils.reds
@@ -5,7 +5,7 @@ public static func E(msg: String) -> Void {
 }
 public static func F(msg: String, opt context: String) -> Void {
     let error = s"[ERROR]";
-    if NotEquals(context, "") { error += s" \(context)"; }
+    if NotEquals(context, "") { error += s"[\(context)]"; }
     error += s" \(msg)";
     E(error);
 }

--- a/audioware/reds/Utils.reds
+++ b/audioware/reds/Utils.reds
@@ -1,0 +1,11 @@
+module Audioware
+
+public static func E(msg: String) -> Void {
+    ModLog(n"Audioware", AsRef(msg));
+}
+public static func F(msg: String, opt context: String) -> Void {
+    let error = s"[ERROR]";
+    if NotEquals(context, "") { error += s" \(context)"; }
+    error += s" \(msg)";
+    E(error);
+}

--- a/audioware/src/engine/manager.rs
+++ b/audioware/src/engine/manager.rs
@@ -10,7 +10,8 @@ lazy_static! {
 }
 
 pub fn setup() {
-    let mut manager = AudioManager::new(AudioManagerSettings::default()).unwrap();
+    let mut manager =
+        AudioManager::new(AudioManagerSettings::default()).expect("unable to create audio manager");
     if engine::tracks::setup(&mut manager).is_err() {
         red4ext_rs::error!("error initializing tracks on Audio Manager");
     }

--- a/audioware/src/engine/mod.rs
+++ b/audioware/src/engine/mod.rs
@@ -24,6 +24,10 @@ pub fn setup() -> anyhow::Result<()> {
 
 #[inline]
 pub fn update_state(state: State) {
+    if state == State::Unreachable {
+        red4ext_rs::error!("unreachable State is not meant to be set from .reds");
+        return;
+    }
     let previous = state::update(state);
     match (previous, state) {
         (State::InGame, State::InMenu) | (State::InGame, State::InPause) => {

--- a/audioware/src/engine/state.rs
+++ b/audioware/src/engine/state.rs
@@ -14,7 +14,7 @@ pub fn update(state: State) -> State {
     STATE
         .swap(state as u8, std::sync::atomic::Ordering::SeqCst)
         .try_into()
-        .unwrap()
+        .expect("unable to update game state")
 }
 
 #[allow(dead_code)]
@@ -22,7 +22,7 @@ pub fn load() -> State {
     STATE
         .load(std::sync::atomic::Ordering::Relaxed)
         .try_into()
-        .unwrap()
+        .expect("unable to load game state")
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -45,6 +45,8 @@ pub enum State {
     End = 6,
     /// unload game
     Unload = 7,
+    /// error
+    Unreachable = 8,
 }
 
 unsafe impl NativeRepr for State {

--- a/audioware/src/engine/state.rs
+++ b/audioware/src/engine/state.rs
@@ -66,7 +66,9 @@ impl TryFrom<u8> for State {
             v if State::InPause as u8 == v => Ok(State::InPause),
             v if State::End as u8 == v => Ok(State::End),
             v if State::Unload as u8 == v => Ok(State::Unload),
-            v if State::Unreachable as u8 == v => anyhow::bail!(format!("unreachable State ({})", value)),
+            v if State::Unreachable as u8 == v => {
+                anyhow::bail!(format!("unreachable State ({})", value))
+            }
             _ => anyhow::bail!(format!("invalid State ({})", value)),
         }
     }

--- a/audioware/src/types/redmod.rs
+++ b/audioware/src/types/redmod.rs
@@ -106,7 +106,14 @@ impl AsRef<std::path::Path> for Mod {
 impl Mod {
     /// get mod folder name (file stem)
     pub fn name(&self) -> ModName {
-        ModName(self.0.file_stem().unwrap().to_str().unwrap().to_string())
+        ModName(
+            self.0
+                .file_stem()
+                .expect("unable to get folder stem")
+                .to_str()
+                .expect("unable to get folder name")
+                .to_string(),
+        )
     }
 }
 

--- a/audioware/src/types/voice.rs
+++ b/audioware/src/types/voice.rs
@@ -171,14 +171,14 @@ mod tests {
             file: Some("en-us/v_sq017_f_19795c050029f000.Wav".into()),
             subtitle: "Again?".to_string(),
         };
-        let validation = audio.validate_args(folder.as_path());
+        let validation = audio.validate_with_args(folder.as_path());
         assert!(validation.is_ok());
 
         let audio = AudioSubtitle {
             file: Some("en-us/../../v_sq017_f_19795c050029f000.Wav".into()),
             subtitle: "Again?".to_string(),
         };
-        let validation = audio.validate_args(folder.as_path());
+        let validation = audio.validate_with_args(folder.as_path());
         assert!(validation.is_err());
     }
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,8 +12,3 @@ audioware-mem.workspace = true
 syn = "2"
 proc-macro2 = "1"
 quote = "1"
-
-[dev-dependencies]
-lazy_static.workspace = true
-red4ext-rs.workspace = true
-retour.workspace = true

--- a/mem/Cargo.toml
+++ b/mem/Cargo.toml
@@ -10,6 +10,6 @@ rust-version.workspace = true
 cxx.workspace = true
 lazy_static.workspace = true
 red4ext-rs.workspace = true
-retour = "0.3.1"
-widestring = "1.0.2"
+retour.workspace = true
+widestring = "1.1.0"
 winapi = { version = "0.3.9", features = ["libloaderapi"] }

--- a/mem/src/hook.rs
+++ b/mem/src/hook.rs
@@ -34,9 +34,8 @@ macro_rules! hook {
                 let _ = $storage
                 .clone()
                 .borrow_mut()
-                .lock()
-                .unwrap()
-                .take();
+                .try_lock()
+                .map(|x| x.take());
             }
         }
     };


### PR DESCRIPTION
As reported on Nexus
![Screenshot 2024-05-06 225930](https://github.com/cyb3rpsych0s1s/audioware/assets/21016014/a8a72c3a-e32d-47eb-a5c4-37d652ac7f26)

and experimented myself after updating to following libs version:
- CET `1.32.1` ➡️ `1.32.2`
- TweakXL `1.8.4` ➡️ `1.8.5`
- ArchiveXL `1.12.2` ➡️ `1.14.1`

libs untouched:
- RED4ext `1.24.3`
- Codeware `1.9.0`
- Redscript `0.5.19`
- RedHotTools `0.9.2`
- red4ext-rs `rev = "8e938fa"`

```cpp
Error reason: Unhandled exception
Expression: EXCEPTION_ACCESS_VIOLATION (0xC0000005)
Message: The thread caused a user-mode data execution prevention (DEP) violation at 0x7FFE341C4510.
File: <Unknown>(0)
```
![Screenshot 2024-05-06 232654](https://github.com/cyb3rpsych0s1s/audioware/assets/21016014/9b82ccfd-8fc6-4013-84be-9a77b30a0bd6)
