### PR TITLE
Automate detouring native event handlers

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,9 @@
 name: CI
 on: push
 
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   quality:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   IS_DRAFT: ${{ startsWith(github.ref_name, 'beta') || startsWith(github.ref_name, 'alpha') }}
   IS_PRERELEASE: ${{ startsWith(github.ref_name, 'rc') }}
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   bundle:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ kira = "0.9.0"
 memoffset = "0.9.1"
 once_cell = "1.19.0"
 mint = "0.5.9"
-red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs.git", rev = "8e938fa", features = ["macros"] }
+red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs.git", rev = "8e938fa567afe71178268fbad0f7ea4da614eeb5", features = ["macros"] }
 retour = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"

--- a/audioware/src/addresses.rs
+++ b/audioware/src/addresses.rs
@@ -6,3 +6,6 @@ pub const ON_AUDIOSYSTEM_PLAY: usize = 0x140974F58 - IMAGE_BASE;
 pub const ON_AUDIOSYSTEM_STOP: usize = 0x1424503C8 - IMAGE_BASE;
 /// memory address for [AudioSystem::Switch](https://codeberg.org/adamsmasher/cyberpunk/src/branch/master/core/systems/audioSystem.swift#L14)
 pub const ON_AUDIOSYSTEM_SWITCH: usize = 0x140291688 - IMAGE_BASE;
+
+/// memory address for [AudioEvent](https://codeberg.org/adamsmasher/cyberpunk/src/branch/master/orphans.swift#18091)
+pub const ON_ENTAUDIOEVENT: usize = 0x140816DF4 - IMAGE_BASE;

--- a/audioware/src/intercept.rs
+++ b/audioware/src/intercept.rs
@@ -1,0 +1,37 @@
+use audioware_macros::NativeHandler;
+use audioware_mem::FromMemory;
+use audioware_sys::interop::audio::AudioEvent;
+
+use crate::addresses::ON_ENTAUDIOEVENT;
+
+pub fn print_ent_audio_event(event: AudioEvent) {
+    use red4ext_rs::conv::ClassType;
+    let AudioEvent {
+        event_name,
+        emitter_name,
+        name_data,
+        float_data,
+        event_type,
+        event_flags,
+        ..
+    } = event;
+    red4ext_rs::info!(
+        "intercepted {} ({}):\nevent_name: {}\nemitter_name: {}\nname_data: {}\nfloat_data: {}\nevent_type: {}\nevent_flags: {}\n",
+        AudioEvent::NAME,
+        AudioEvent::NATIVE_NAME,
+        event_name,
+        emitter_name,
+        name_data,
+        float_data,
+        event_type,
+        event_flags
+    );
+}
+
+#[derive(NativeHandler)]
+#[hook(
+    offset = ON_ENTAUDIOEVENT,
+    event = "audioware_sys::interop::audio::AudioEvent",
+    detour = "print_ent_audio_event"
+)]
+pub struct HookentAudioEvent;

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -50,6 +50,7 @@ use red4ext_rs::{define_trait_plugin, plugin::Plugin};
 mod addresses;
 pub mod engine;
 mod hook;
+mod intercept;
 mod language;
 pub mod natives;
 mod types;
@@ -131,6 +132,12 @@ impl Plugin for Audioware {
         HookAudioSystemPlay::load();
         HookAudioSystemStop::load();
         HookAudioSystemSwitch::load();
+
+        #[cfg(debug_assertions)]
+        {
+            use audioware_mem::Intercept;
+            intercept::HookentAudioEvent::load();
+        }
     }
 
     fn unload() {
@@ -138,6 +145,12 @@ impl Plugin for Audioware {
         HookAudioSystemPlay::unload();
         HookAudioSystemStop::unload();
         HookAudioSystemSwitch::unload();
+
+        #[cfg(debug_assertions)]
+        {
+            use audioware_mem::Intercept;
+            intercept::HookentAudioEvent::unload();
+        }
     }
 
     fn is_version_independent() -> bool {

--- a/audioware/src/types/id.rs
+++ b/audioware/src/types/id.rs
@@ -13,17 +13,16 @@ impl std::hash::Hash for SoundEntityId {
 
 macro_rules! id {
     ($target:ident, $visitor:ident) => {
-
         #[derive(Debug, Clone, PartialEq, Eq)]
         #[repr(transparent)]
         pub struct $target(CName);
-        
+
         impl std::hash::Hash for $target {
             fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
                 u64::from(self.0.clone()).hash(state);
             }
         }
-        
+
         impl AsRef<CName> for $target {
             fn as_ref(&self) -> &CName {
                 &self.0

--- a/mem/src/hook.rs
+++ b/mem/src/hook.rs
@@ -1,3 +1,5 @@
+//! deprecated, only kept around for learning purpose
+
 #[macro_export]
 macro_rules! hook {
     ($name:ident, $address:ident, $fn_ty:ty, $hook:ident, $storage:ident) => {

--- a/mem/src/module.rs
+++ b/mem/src/module.rs
@@ -2,7 +2,10 @@ use retour::RawDetour;
 use widestring::U16CString;
 use winapi::{shared::minwindef::HMODULE, um::libloaderapi::GetModuleHandleW};
 
-use crate::{ExternFnRedRegisteredFunc, LocalFnRustRegisteredFunc};
+use crate::{
+    ExternFnRedRegisteredFunc, ExternFnRedRegisteredHandler, LocalFnRustRegisteredFunc,
+    LocalFnRustRegisteredHandler,
+};
 
 /// get a Windows module address in memory.
 ///
@@ -36,10 +39,10 @@ unsafe fn locate(offset: usize) -> usize {
 /// memory offset must be for a valid native event handler function.
 pub unsafe fn load_native_event_handler(
     offset: usize,
-    hook: fn(usize, usize) -> (),
+    hook: LocalFnRustRegisteredHandler,
 ) -> Result<RawDetour, ::retour::Error> {
     let address = unsafe { self::locate(offset) };
-    let vanilla: extern "C" fn(usize, usize) -> () = unsafe { ::std::mem::transmute(address) };
+    let vanilla: ExternFnRedRegisteredHandler = unsafe { ::std::mem::transmute(address) };
     unsafe { ::retour::RawDetour::new(vanilla as *const (), hook as *const ()) }
 }
 

--- a/sys/src/interop/audio.rs
+++ b/sys/src/interop/audio.rs
@@ -1,7 +1,10 @@
 use audioware_macros::FromMemory;
-use red4ext_rs::{conv::NativeRepr, types::CName};
+use red4ext_rs::{
+    conv::{ClassType, NativeRepr},
+    types::CName,
+};
 
-use super::iscriptable::ISCRIPTABLE_SIZE;
+use super::{event::Event, iscriptable::ISCRIPTABLE_SIZE};
 
 /// see [RED4ext::audio::EventActionType](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/Generated/audio/EventActionType.hpp).
 #[derive(Debug, Clone, Copy, strum_macros::Display, strum_macros::FromRepr, PartialEq)]
@@ -49,6 +52,20 @@ pub struct AudioEvent {
     pub event_type: AudioEventActionType,
     pub event_flags: AudioAudioEventFlags,
     unk64: i32,
+}
+
+impl ClassType for AudioEvent {
+    type BaseClass = Event;
+    const NAME: &'static str = "AudioEvent";
+    const NATIVE_NAME: &'static str = "entAudioEvent";
+}
+
+#[cfg(test)]
+mod memory {
+    #[test]
+    fn size() {
+        static_assertions::const_assert_eq!(std::mem::size_of::<super::AudioEvent>(), 0x68);
+    }
 }
 
 /// see [RED4ext::scn::DialogLineType](https://github.com/WopsS/RED4ext.SDK/blob/master/include/RED4ext/Scripting/Natives/Generated/scn/DialogLineType.hpp).


### PR DESCRIPTION
This could come in handy when introspecting the various audio events from the game, or later on to add automation features to Audioware.