### PR TITLE
Skip emitters sync when not actively playing

### DIFF
--- a/audioware/reds/Service.reds
+++ b/audioware/reds/Service.reds
@@ -25,6 +25,10 @@ class AudiowareService extends ScriptableService {
             .RegisterCallback(n"Session/BeforeEnd", this, n"OnSessionChange");
         GameInstance.GetCallbackSystem()
             .RegisterCallback(n"Session/End", this, n"OnSessionChange");
+        // main menu (pre-game)
+        GameInstance.GetCallbackSystem()
+            .RegisterCallback(n"Resource/Ready", this, n"OnMainMenuResourceReady")
+            .AddTarget(ResourceTarget.Path(r"base\\gameplay\\gui\\fullscreen\\main_menu\\pregame_menu.inkmenu"));
 
         this.RegisterOnLoad();
     }
@@ -66,6 +70,11 @@ class AudiowareService extends ScriptableService {
             default:
                 break;
         }
+    }
+
+    private cb func OnMainMenuResourceReady(event: ref<ResourceEvent>) {
+        LOG("on main menu ready: AudiowareService");
+        SetGameState(GameState.Menu);
     }
 
     public static func GetInstance() -> ref<AudiowareService> {

--- a/audioware/src/engine.rs
+++ b/audioware/src/engine.rs
@@ -127,6 +127,12 @@ impl Engine {
             );
         }
     }
+    pub fn toggle_sync_emitters(enable: bool) {
+        Scene::toggle_emitters_sync(enable);
+    }
+    pub fn should_sync_emitters() -> bool {
+        Scene::should_sync_emitters()
+    }
     pub fn sync_emitters() {
         if let Err(e) = Scene::sync_emitters() {
             log::error!(Audioware::env(), "couldn't sync emitters on scene: {e}");

--- a/audioware/src/engine/modulators/playback.rs
+++ b/audioware/src/engine/modulators/playback.rs
@@ -1,0 +1,38 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use kira::{
+    manager::AudioManager,
+    modulator::tweener::{TweenerBuilder, TweenerHandle},
+    sound::PlaybackRate,
+    spatial::scene::SpatialSceneHandle,
+    tween::{ModulatorMapping, Tween, Value},
+};
+
+use crate::error::InternalError;
+
+const MODULATOR_NAME: &str = "TimeDilationPlayback";
+static MODULATOR: OnceLock<Mutex<TweenerHandle>> = OnceLock::new();
+
+pub struct TimeDilationPlayback;
+impl TimeDilationPlayback {
+    pub fn try_lock<'a>() -> Result<MutexGuard<'a, TweenerHandle>, InternalError> {
+        MODULATOR
+            .get()
+            .unwrap()
+            .try_lock()
+            .map_err(|_| InternalError::Contention {
+                origin: MODULATOR_NAME,
+            })
+    }
+}
+
+impl TimeDilationPlayback {
+    pub(super) fn setup(manager: &mut AudioManager) -> Result<(), crate::error::Error> {
+        let handle = manager.add_modulator(TweenerBuilder { initial_value: 0.0 })?;
+        MODULATOR
+            .set(Mutex::new(handle))
+            .expect("store tweener handle once");
+
+        Ok(())
+    }
+}

--- a/audioware/src/hooks/on_transform_updated.rs
+++ b/audioware/src/hooks/on_transform_updated.rs
@@ -26,6 +26,9 @@ pub fn attach_hook(env: &SdkEnv) {
 #[allow(unused_variables)]
 unsafe extern "C" fn detour(i: *mut IScriptable, cb: unsafe extern "C" fn(i: *mut IScriptable)) {
     cb(i);
+    if !Engine::should_sync_emitters() {
+        return;
+    }
     let now = Instant::now();
     let (sync, reclaim) = (
         SYNC_DELTA_TIME

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -9,7 +9,7 @@ use red4ext_rs::{
     wcstr, ClassExport, Exportable, GameApp, GlobalExport, Plugin, PluginOps, RttiRegistrator,
     RttiSystem, ScriptClass, SdkEnv, SemVer, StateListener, U16CStr,
 };
-use states::{GameState, State};
+use states::{GameState, State, ToggleState};
 use types::{
     Args, AsAudioSystem, AudioSystem, EmitterDistances, EmitterSettings, GameObject, LoopRegion,
     Vector4,
@@ -152,7 +152,10 @@ impl Plugin for Audioware {
                 c"Audioware.SupportedLanguages",
                 Engine::supported_languages
             )),
-            GlobalExport(global!(c"Audioware.SetGameState", GameState::set)),
+            GlobalExport(global!(
+                c"Audioware.SetGameState",
+                GameState::set_and_toggle
+            )),
             GlobalExport(global!(c"Audioware.SetPlayerGender", set_player_gender)),
             GlobalExport(global!(c"Audioware.UnsetPlayerGender", unset_player_gender)),
             GlobalExport(global!(c"Audioware.SetGameLocales", set_game_locales)),

--- a/audioware/src/states.rs
+++ b/audioware/src/states.rs
@@ -1,12 +1,21 @@
 mod game;
 pub use game::GameState;
+
 mod player;
 
 pub trait State {
-    type Value;
+    type Value: PartialEq + Clone;
     fn swap(value: Self::Value) -> Self::Value;
-    fn set(value: Self::Value) {
-        let _ = Self::swap(value);
+    fn set(value: Self::Value) -> Self::Value {
+        Self::swap(value.clone())
     }
     fn get() -> Self::Value;
+}
+
+pub trait ToggleState: State {
+    fn set_and_toggle(value: Self::Value) {
+        let prior = Self::set(value.clone());
+        Self::toggle(prior, value);
+    }
+    fn toggle(before: Self::Value, after: Self::Value);
 }

--- a/manifest/src/types/locale.rs
+++ b/manifest/src/types/locale.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use core::fmt;
 
 /// Locale currently used for e.g. subtitles and UI texts.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SpokenLocale(Locale);
 
 impl fmt::Display for SpokenLocale {
@@ -36,7 +36,7 @@ impl TryFrom<red4ext_rs::types::CName> for SpokenLocale {
 }
 
 /// Locale currently set for e.g. voices and dialogs.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WrittenLocale(Locale);
 
 impl WrittenLocale {
@@ -81,6 +81,8 @@ impl TryFrom<red4ext_rs::types::CName> for WrittenLocale {
     Serialize,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     Key,
     strum_macros::Display,


### PR DESCRIPTION
Skip scene audio emitters sync when not actively playing.
This PR disable sync on main menu pre-game, inside any menu in-game and during (most) of the loading phases.
"Most" because the game actually briefly preloads world and entities in-between in-game sessions.