### PR TITLE
Fixes

### DIFF
--- a/audioware/reds/Debug.reds
+++ b/audioware/reds/Debug.reds
@@ -102,7 +102,7 @@ public static exec func TestAudioSystemStopOnEmitter(game: GameInstance, name: S
     let target = GameInstance.GetTargetingSystem(game).GetLookAtObject(GetPlayer(game));
     emitterID = target.GetEntityID();
 
-    StopOnEmitter(cname, emitterID, n"Jean-Michel");
+    GameInstance.GetAudioSystemExt(game).StopOnEmitter(cname, emitterID, n"Jean-Michel");
 }
 
 /// Game.TestAudioSystemPlayOverThePhone("nah_everything_is_all_good");

--- a/audioware/reds/DebugExt.reds
+++ b/audioware/reds/DebugExt.reds
@@ -30,7 +30,12 @@ public class AutoEmittersSystem extends ScriptableSystem {
             n"dok_mai_gab_jeh_gan", 
             n"ton",
             n"dimanche_aux_goudes",
-            n"feel_good_inc"
+            n"feel_good_inc",
+            n"straight_outta_compton",
+            n"welcome_to_brownsville",
+            n"sultans_of_swing",
+            n"ghetto_vet",
+            n"get_off_the_ground"
         ];
         let eventName = sounds[RandRange(0, ArraySize(sounds) -1)];
         let tween = new LinearTween();

--- a/audioware/reds/Natives.reds
+++ b/audioware/reds/Natives.reds
@@ -23,27 +23,17 @@ private native func Shutdown() -> Void;
 
 private native func RegisterEmitter(emitterID: EntityID, opt emitterName: CName, opt emitterSettings: EmitterSettings) -> Bool;
 private native func UnregisterEmitter(emitterID: EntityID) -> Bool;
-private native func EmittersCount() -> Int32;
-private native func IsRegisteredEmitter(entityID: EntityID) -> Bool;
 
 private native func SetGameState(state: GameState) -> Void;
 private native func SetPlayerGender(gender: PlayerGender) -> Void;
 private native func UnsetPlayerGender() -> Void;
 private native func SetGameLocales(spoken: CName, written: CName) -> Void;
 
+private native func Pause(opt tween: ref<Tween>) -> Void;
+private native func Resume(opt tween: ref<Tween>) -> Void;
+
 private native func SetReverbMix(value: Float) -> Void;
 private native func SetPreset(value: Preset) -> Void;
-
-public native func PlayOverThePhone(eventName: CName, emitterName: CName, gender: CName) -> Void;
-public native func Play(eventName: CName, opt entityID: EntityID, opt emitterName: CName, opt line: scnDialogLineType, opt tween: ref<Tween>) -> Void;
-public native func Stop(eventName: CName, opt entityID: EntityID, opt emitterName: CName, opt tween: ref<Tween>) -> Void;
-public native func Switch(switchName: CName, switchValue: CName, opt entityID: EntityID, opt emitterName: CName, opt switchNameTween: ref<Tween>, opt switchValueTween: ref<Tween>) -> Void;
-public native func Pause(opt tween: ref<Tween>) -> Void;
-public native func Resume(opt tween: ref<Tween>) -> Void;
-
-public native func PlayOnEmitter(eventName: CName, entityID: EntityID, emitterName: CName, opt tween: ref<Tween>) -> Void;
-public native func StopOnEmitter(eventName: CName, entityID: EntityID, emitterName: CName, opt tween: ref<Tween>) -> Void;
-
 private native func SetVolume(setting: CName, value: Double) -> Void;
 
 enum GameState {

--- a/audioware/reds/Service.reds
+++ b/audioware/reds/Service.reds
@@ -28,7 +28,8 @@ class AudiowareService extends ScriptableService {
         // main menu (pre-game)
         GameInstance.GetCallbackSystem()
             .RegisterCallback(n"Resource/Ready", this, n"OnMainMenuResourceReady")
-            .AddTarget(ResourceTarget.Path(r"base\\gameplay\\gui\\fullscreen\\main_menu\\pregame_menu.inkmenu"));
+            .AddTarget(ResourceTarget.Path(r"base\\gameplay\\gui\\fullscreen\\main_menu\\pregame_menu.inkmenu"))
+            .SetRunMode(CallbackRunMode.Once);
 
         this.RegisterModSettings();
     }

--- a/audioware/reds/Service.reds
+++ b/audioware/reds/Service.reds
@@ -30,11 +30,11 @@ class AudiowareService extends ScriptableService {
             .RegisterCallback(n"Resource/Ready", this, n"OnMainMenuResourceReady")
             .AddTarget(ResourceTarget.Path(r"base\\gameplay\\gui\\fullscreen\\main_menu\\pregame_menu.inkmenu"));
 
-        this.RegisterOnLoad();
+        this.RegisterModSettings();
     }
 
     private cb func OnUninitialize() {
-        this.UnregisterOnUninitialize();
+        this.UnregisterModSettings();
     }
 
     private cb func OnSessionChange(event: ref<GameSessionEvent>) {
@@ -86,14 +86,14 @@ class AudiowareService extends ScriptableService {
     // audio config
 
     @if(ModuleExists("ModSettingsModule"))
-    private func RegisterOnLoad() { ModSettings.RegisterListenerToModifications(this); }
+    private func RegisterModSettings() { ModSettings.RegisterListenerToModifications(this); }
     @if(ModuleExists("ModSettingsModule"))
-    private func UnregisterOnUninitialize() { ModSettings.UnregisterListenerToModifications(this); }
+    private func UnregisterModSettings() { ModSettings.UnregisterListenerToModifications(this); }
 
     @if(!ModuleExists("ModSettingsModule"))
-    private func RegisterOnLoad() -> Void {}
+    private func RegisterModSettings() -> Void {}
     @if(!ModuleExists("ModSettingsModule"))
-    private func UnregisterOnUninitialize() -> Void {}
+    private func UnregisterModSettings() -> Void {}
     
     public func OnModSettingsChange() { this.RefreshConfig(); }
     public func RefreshConfig() -> Void {

--- a/audioware/reds/Service.reds
+++ b/audioware/reds/Service.reds
@@ -74,7 +74,6 @@ class AudiowareService extends ScriptableService {
 
     private cb func OnMainMenuResourceReady(event: ref<ResourceEvent>) {
         LOG("on main menu ready: AudiowareService");
-        SetGameState(GameState.Menu);
     }
 
     public static func GetInstance() -> ref<AudiowareService> {

--- a/audioware/reds/System.reds
+++ b/audioware/reds/System.reds
@@ -190,7 +190,7 @@ public class AudiowareSystem extends ScriptableSystem {
     }
 
     public func UnregisterEmitter(entityID: EntityID) -> Void {
-        if IsRegisteredEmitter(entityID) {
+        if GameInstance.GetAudioSystemExt(this.GetGameInstance()).IsRegisteredEmitter(entityID) {
             UnregisterEmitter(entityID);
             this.detachedOnce.RemoveTarget(EntityTarget.ID(entityID));
         }
@@ -206,7 +206,7 @@ public class AudiowareSystem extends ScriptableSystem {
         }
         // ignore EntityTarget placeholder, we only care about emitters here
         if !entity.IsA(n"PlayerPuppet") {
-            let already = IsRegisteredEmitter(id);
+            let already = GameInstance.GetAudioSystemExt(this.GetGameInstance()).IsRegisteredEmitter(id);
             if !already {
                 let registered = RegisterEmitter(id);
                 if registered {
@@ -224,7 +224,7 @@ public class AudiowareSystem extends ScriptableSystem {
             let id = entity.GetEntityID();
             let display = EntityID.ToDebugString(id);
             LOG(s"on emitter despawn: AudiowareSystem (\(display))");
-            let registered = IsRegisteredEmitter(id);
+            let registered = GameInstance.GetAudioSystemExt(this.GetGameInstance()).IsRegisteredEmitter(id);
             if registered {
                 LOG(s"on emitter despawn while registered: AudiowareSystem (\(display))");
                 let unregistered = UnregisterEmitter(id);

--- a/audioware/src/engine.rs
+++ b/audioware/src/engine.rs
@@ -128,7 +128,7 @@ impl Engine {
         }
     }
     pub fn toggle_sync_emitters(enable: bool) {
-        Scene::toggle_emitters_sync(enable);
+        Scene::toggle_sync_emitters(enable);
     }
     pub fn should_sync_emitters() -> bool {
         Scene::should_sync_emitters()

--- a/audioware/src/engine.rs
+++ b/audioware/src/engine.rs
@@ -3,7 +3,7 @@ use std::sync::MutexGuard;
 use audioware_bank::{Banks, Id};
 use audioware_manifest::{PlayerGender, ScnDialogLineType, Source, SpokenLocale, WrittenLocale};
 use kira::{manager::AudioManager, OutputDestination, Volume};
-use manager::PlayAndStore;
+use manager::{Pause, PlayAndStore, Resume, StopBy, StopFor};
 use modulators::{
     CarRadioVolume, DialogueVolume, MusicVolume, Parameter, RadioportVolume, ReverbMix, SfxVolume,
 };
@@ -36,7 +36,6 @@ mod tracks;
 pub use effects::IMMEDIATELY;
 pub use eq::EqPass;
 pub use eq::Preset;
-pub use manager::Manage;
 pub use manager::Manager;
 pub use scene::Scene;
 pub use settings::*;
@@ -70,7 +69,7 @@ impl Engine {
         Banks::languages().into_iter().map(|x| x.into()).collect()
     }
     pub fn shutdown() {
-        if let Err(e) = Manager::clear_tracks(None) {
+        if let Err(e) = Manager.clear_tracks(None) {
             log::error!(Audioware::env(), "couldn't clear tracks on manager: {e}");
         }
         if let Err(e) = Scene::clear_emitters() {
@@ -243,7 +242,7 @@ impl Engine {
         let emitter_name = emitter_name.into_option();
         let tween = tween.into_tween();
         log::info!(env, "stop called: {entity_id:?} {emitter_name:?} {tween:?}");
-        if let Err(e) = Manager::stop_by(
+        if let Err(e) = Manager.stop_by(
             &event_name,
             entity_id.as_ref(),
             emitter_name.as_ref(),
@@ -253,12 +252,12 @@ impl Engine {
         }
     }
     pub fn pause(tween: Ref<Tween>) {
-        if let Err(e) = Manager::pause(tween.into_tween()) {
+        if let Err(e) = Manager.pause(tween.into_tween()) {
             log::error!(Audioware::env(), "{e}");
         }
     }
     pub fn resume(tween: Ref<Tween>) {
-        if let Err(e) = Manager::resume(tween.into_tween()) {
+        if let Err(e) = Manager.resume(tween.into_tween()) {
             log::error!(Audioware::env(), "{e}");
         }
     }
@@ -330,7 +329,7 @@ impl Engine {
         emitter_name: CName,
         tween: Ref<Tween>,
     ) {
-        if let Err(e) = Manager::stop_by(
+        if let Err(e) = Manager.stop_by(
             &event_name,
             Some(&entity_id),
             Some(&emitter_name),
@@ -341,7 +340,7 @@ impl Engine {
     }
     #[allow(dead_code)]
     pub fn stop_for(entity_id: EntityId) {
-        if let Err(e) = Manager::stop_for(&entity_id, None) {
+        if let Err(e) = Manager.stop_for(&entity_id, None) {
             log::error!(Audioware::env(), "{e}");
         }
     }

--- a/audioware/src/engine.rs
+++ b/audioware/src/engine.rs
@@ -238,20 +238,18 @@ impl Engine {
         emitter_name: Opt<CName>,
         tween: Ref<Tween>,
     ) {
+        let env = Audioware::env();
         let entity_id = entity_id.into_option();
         let emitter_name = emitter_name.into_option();
         let tween = tween.into_tween();
-        log::info!(
-            Audioware::env(),
-            "stop called: {entity_id:?} {emitter_name:?} {tween:?}"
-        );
+        log::info!(env, "stop called: {entity_id:?} {emitter_name:?} {tween:?}");
         if let Err(e) = Manager::stop_by(
             &event_name,
             entity_id.as_ref(),
             emitter_name.as_ref(),
             tween,
         ) {
-            log::error!(Audioware::env(), "{e}");
+            log::error!(env, "{e}");
         }
     }
     pub fn pause(tween: Ref<Tween>) {

--- a/audioware/src/engine/manager.rs
+++ b/audioware/src/engine/manager.rs
@@ -263,7 +263,6 @@ where
 {
     type Handle = <T as SoundData>::Handle;
 
-    #[inline]
     fn play(
         self,
         manager: &mut AudioManager,
@@ -383,7 +382,6 @@ where
     <T as SoundData>::Handle: Store,
     U: ToTween,
 {
-    #[inline]
     fn play_and_store(
         self,
         manager: &mut AudioManager,
@@ -431,7 +429,6 @@ where
 {
     type Handle = <T as SoundData>::Handle;
 
-    #[inline]
     fn play(
         self,
         manager: &mut AudioManager,
@@ -454,7 +451,6 @@ where
     PlaySoundError<<T as SoundData>::Error>: Into<Error>,
     <T as SoundData>::Handle: Store,
 {
-    #[inline]
     fn play_and_store(
         self,
         manager: &mut AudioManager,

--- a/audioware/src/engine/manager.rs
+++ b/audioware/src/engine/manager.rs
@@ -43,30 +43,11 @@ pub trait Stopped {
     fn stopped(&self) -> bool;
 }
 
-impl Stopped for StaticSoundHandle {
+impl<T: State> Stopped for T {
+    #[inline]
     fn stopped(&self) -> bool {
         self.state() == PlaybackState::Stopped
     }
-}
-
-impl Stopped for StreamingSoundHandle<FromFileError> {
-    fn stopped(&self) -> bool {
-        self.state() == PlaybackState::Stopped
-    }
-}
-
-pub trait Manage {
-    fn stop(&mut self, tween: Option<Tween>);
-    fn stop_by(
-        &mut self,
-        event_name: &CName,
-        entity_id: Option<&EntityId>,
-        emitter_name: Option<&CName>,
-        tween: Option<Tween>,
-    );
-    fn stop_for(&mut self, entity_id: &EntityId, tween: Option<Tween>);
-    fn pause(&mut self, tween: Option<Tween>);
-    fn resume(&mut self, tween: Option<Tween>);
 }
 
 pub struct StaticStorage;
@@ -136,113 +117,13 @@ impl StreamStorage {
 }
 
 impl Manager {
-    pub fn clear_tracks(tween: Option<Tween>) -> Result<(), InternalError> {
-        Self::stop(tween)?;
+    pub fn clear_tracks(&mut self, tween: Option<Tween>) -> Result<(), InternalError> {
+        self.stop(tween)?;
         StaticStorage::try_lock()?.deref_mut().clear();
         StreamStorage::try_lock()?.deref_mut().clear();
         Ok(())
     }
-    pub fn stop(tween: Option<Tween>) -> Result<(), InternalError> {
-        StaticStorage::try_lock()?.deref_mut().stop(tween);
-        StreamStorage::try_lock()?.deref_mut().stop(tween);
-        Ok(())
-    }
-    pub fn stop_by(
-        event_name: &CName,
-        entity_id: Option<&EntityId>,
-        emitter_name: Option<&CName>,
-        tween: Option<Tween>,
-    ) -> Result<(), InternalError> {
-        StaticStorage::try_lock()?
-            .deref_mut()
-            .stop_by(event_name, entity_id, emitter_name, tween);
-        StreamStorage::try_lock()?
-            .deref_mut()
-            .stop_by(event_name, entity_id, emitter_name, tween);
-        Ok(())
-    }
-    #[allow(dead_code)]
-    pub fn stop_for(entity_id: &EntityId, tween: Option<Tween>) -> Result<(), InternalError> {
-        StaticStorage::try_lock()?
-            .deref_mut()
-            .stop_for(entity_id, tween);
-        StreamStorage::try_lock()?
-            .deref_mut()
-            .stop_for(entity_id, tween);
-        Ok(())
-    }
-    pub fn pause(tween: Option<Tween>) -> Result<(), InternalError> {
-        StaticStorage::try_lock()?.deref_mut().pause(tween);
-        StreamStorage::try_lock()?.deref_mut().pause(tween);
-        Ok(())
-    }
-    pub fn resume(tween: Option<Tween>) -> Result<(), InternalError> {
-        StaticStorage::try_lock()?.deref_mut().resume(tween);
-        StreamStorage::try_lock()?.deref_mut().resume(tween);
-        Ok(())
-    }
 }
-
-macro_rules! impl_manage {
-    ($value_ty:ty) => {
-        impl Manage for $value_ty {
-            fn stop(&mut self, tween: Option<kira::tween::Tween>) {
-                self.par_iter_mut()
-                    .filter(|v| {
-                        v.value().state() != PlaybackState::Stopped
-                            && v.value().state() != PlaybackState::Stopping
-                    })
-                    .for_each(|mut v| v.value_mut().stop(tween.unwrap_or_default()));
-            }
-
-            fn stop_by(
-                &mut self,
-                event_name: &CName,
-                entity_id: Option<&EntityId>,
-                emitter_name: Option<&CName>,
-                tween: Option<Tween>,
-            ) {
-                self.par_iter_mut()
-                    .filter(|entry| {
-                        entry.key().event_name() == event_name
-                            && entry.key().entity_id() == entity_id
-                            && entry.key().emitter_name() == emitter_name
-                            && entry.value().state() != PlaybackState::Stopped
-                            && entry.value().state() != PlaybackState::Stopping
-                    })
-                    .for_each(|mut entry| entry.value_mut().stop(tween.unwrap_or_default()));
-            }
-
-            fn stop_for(&mut self, entity_id: &EntityId, tween: Option<Tween>) {
-                self.par_iter_mut()
-                    .filter(|entry| {
-                        entry.key().entity_id() == Some(entity_id)
-                            && entry.value().state() != PlaybackState::Stopped
-                            && entry.value().state() != PlaybackState::Stopping
-                    })
-                    .for_each(|mut entry| entry.value_mut().stop(tween.unwrap_or_default()));
-            }
-
-            fn pause(&mut self, tween: Option<kira::tween::Tween>) {
-                self.par_iter_mut()
-                    .filter(|entry| entry.value().state() == PlaybackState::Playing)
-                    .for_each(|mut entry| entry.value_mut().pause(tween.unwrap_or_default()));
-            }
-
-            fn resume(&mut self, tween: Option<kira::tween::Tween>) {
-                self.par_iter_mut()
-                    .filter(|entry| {
-                        entry.value().state() == PlaybackState::Paused
-                            || entry.value().state() == PlaybackState::Pausing
-                    })
-                    .for_each(|mut entry| entry.value_mut().resume(tween.unwrap_or_default()));
-            }
-        }
-    };
-}
-
-impl_manage!(DashMap<HandleId,StaticSoundHandle>);
-impl_manage!(DashMap<HandleId,StreamingSoundHandle<FromFileError>>);
 
 pub trait Play<T> {
     type Handle;
@@ -484,5 +365,256 @@ impl PlayAndStore<Ref<AudioSettingsExt>> for Manager {
                 data.play_and_store(manager, id, entity_id, emitter_name, destination, ext)
             }
         }
+    }
+}
+
+pub trait Stop {
+    type Output;
+
+    fn stop(&mut self, tween: Option<Tween>) -> Self::Output;
+}
+
+impl<T: Send + Sync + State + Stop> Stop for DashMap<HandleId, T> {
+    type Output = ();
+
+    fn stop(&mut self, tween: Option<Tween>) -> Self::Output {
+        self.par_iter_mut()
+            .filter(|v| {
+                v.value().state() != PlaybackState::Stopped
+                    && v.value().state() != PlaybackState::Stopping
+            })
+            .for_each(|mut v| {
+                v.value_mut().stop(tween);
+            });
+    }
+}
+
+pub trait State {
+    fn state(&self) -> PlaybackState;
+}
+
+impl State for StaticSoundHandle {
+    #[inline]
+    fn state(&self) -> PlaybackState {
+        Self::state(self)
+    }
+}
+
+impl State for StreamingSoundHandle<FromFileError> {
+    #[inline]
+    fn state(&self) -> PlaybackState {
+        Self::state(self)
+    }
+}
+
+impl Stop for Manager {
+    type Output = Result<(), InternalError>;
+
+    fn stop(&mut self, tween: Option<Tween>) -> Result<(), InternalError> {
+        StaticStorage::try_lock()?.deref_mut().stop(tween);
+        StreamStorage::try_lock()?.deref_mut().stop(tween);
+        Ok(())
+    }
+}
+
+impl Stop for StaticSoundHandle {
+    type Output = ();
+
+    #[inline]
+    fn stop(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::stop(self, tween.unwrap_or_default());
+    }
+}
+
+impl Stop for StreamingSoundHandle<FromFileError> {
+    type Output = ();
+
+    #[inline]
+    fn stop(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::stop(self, tween.unwrap_or_default());
+    }
+}
+
+pub trait StopBy {
+    type Output;
+
+    fn stop_by(
+        &mut self,
+        event_name: &CName,
+        entity_id: Option<&EntityId>,
+        emitter_name: Option<&CName>,
+        tween: Option<Tween>,
+    ) -> Self::Output;
+}
+
+impl StopBy for Manager {
+    type Output = Result<(), InternalError>;
+
+    fn stop_by(
+        &mut self,
+        event_name: &CName,
+        entity_id: Option<&EntityId>,
+        emitter_name: Option<&CName>,
+        tween: Option<Tween>,
+    ) -> Self::Output {
+        StaticStorage::try_lock()?
+            .deref_mut()
+            .stop_by(event_name, entity_id, emitter_name, tween);
+        StreamStorage::try_lock()?
+            .deref_mut()
+            .stop_by(event_name, entity_id, emitter_name, tween);
+        Ok(())
+    }
+}
+
+impl<T: Send + Sync + State + Stop> StopBy for DashMap<HandleId, T> {
+    type Output = ();
+
+    fn stop_by(
+        &mut self,
+        event_name: &CName,
+        entity_id: Option<&EntityId>,
+        emitter_name: Option<&CName>,
+        tween: Option<Tween>,
+    ) -> Self::Output {
+        self.par_iter_mut()
+            .filter(|entry| {
+                entry.key().event_name() == event_name
+                    && entry.key().entity_id() == entity_id
+                    && entry.key().emitter_name() == emitter_name
+                    && entry.value().state() != PlaybackState::Stopped
+                    && entry.value().state() != PlaybackState::Stopping
+            })
+            .for_each(|mut entry| {
+                entry.value_mut().stop(tween);
+            });
+    }
+}
+
+pub trait StopFor {
+    type Output;
+    fn stop_for(&mut self, entity_id: &EntityId, tween: Option<Tween>) -> Self::Output;
+}
+
+impl StopFor for Manager {
+    type Output = Result<(), InternalError>;
+
+    fn stop_for(&mut self, entity_id: &EntityId, tween: Option<Tween>) -> Self::Output {
+        StaticStorage::try_lock()?
+            .deref_mut()
+            .stop_for(entity_id, tween);
+        StreamStorage::try_lock()?
+            .deref_mut()
+            .stop_for(entity_id, tween);
+        Ok(())
+    }
+}
+
+impl<T: Send + Sync + State + Stop> StopFor for DashMap<HandleId, T> {
+    type Output = ();
+
+    fn stop_for(&mut self, entity_id: &EntityId, tween: Option<Tween>) -> Self::Output {
+        self.par_iter_mut()
+            .filter(|entry| {
+                entry.key().entity_id() == Some(entity_id)
+                    && entry.value().state() != PlaybackState::Stopped
+                    && entry.value().state() != PlaybackState::Stopping
+            })
+            .for_each(|mut entry| {
+                entry.value_mut().stop(tween);
+            });
+    }
+}
+
+pub trait Pause {
+    type Output;
+    fn pause(&mut self, tween: Option<Tween>) -> Self::Output;
+}
+
+impl Pause for Manager {
+    type Output = Result<(), InternalError>;
+
+    fn pause(&mut self, tween: Option<Tween>) -> Self::Output {
+        StaticStorage::try_lock()?.deref_mut().pause(tween);
+        StreamStorage::try_lock()?.deref_mut().pause(tween);
+        Ok(())
+    }
+}
+
+impl<T: Send + Sync + State + Pause> Pause for DashMap<HandleId, T> {
+    type Output = ();
+
+    fn pause(&mut self, tween: Option<Tween>) -> Self::Output {
+        self.par_iter_mut()
+            .filter(|entry| entry.value().state() == PlaybackState::Playing)
+            .for_each(|mut entry| {
+                entry.value_mut().pause(tween);
+            });
+    }
+}
+
+impl Pause for StaticSoundHandle {
+    type Output = ();
+
+    #[inline]
+    fn pause(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::pause(self, tween.unwrap_or_default());
+    }
+}
+
+impl Pause for StreamingSoundHandle<FromFileError> {
+    type Output = ();
+
+    #[inline]
+    fn pause(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::pause(self, tween.unwrap_or_default());
+    }
+}
+
+pub trait Resume {
+    type Output;
+    fn resume(&mut self, tween: Option<Tween>) -> Self::Output;
+}
+
+impl Resume for Manager {
+    type Output = Result<(), InternalError>;
+
+    fn resume(&mut self, tween: Option<Tween>) -> Self::Output {
+        StaticStorage::try_lock()?.deref_mut().resume(tween);
+        StreamStorage::try_lock()?.deref_mut().resume(tween);
+        Ok(())
+    }
+}
+
+impl<T: Send + Sync + State + Resume> Resume for DashMap<HandleId, T> {
+    type Output = ();
+
+    fn resume(&mut self, tween: Option<Tween>) -> Self::Output {
+        self.par_iter_mut()
+            .filter(|entry| {
+                entry.value().state() == PlaybackState::Paused
+                    || entry.value().state() == PlaybackState::Pausing
+            })
+            .for_each(|mut entry| {
+                entry.value_mut().resume(tween);
+            });
+    }
+}
+
+impl Resume for StaticSoundHandle {
+    type Output = ();
+
+    #[inline]
+    fn resume(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::resume(self, tween.unwrap_or_default());
+    }
+}
+
+impl Resume for StreamingSoundHandle<FromFileError> {
+    type Output = ();
+
+    #[inline]
+    fn resume(&mut self, tween: Option<Tween>) -> Self::Output {
+        Self::resume(self, tween.unwrap_or_default());
     }
 }

--- a/audioware/src/engine/scene.rs
+++ b/audioware/src/engine/scene.rs
@@ -121,7 +121,7 @@ impl Scene {
                 origin: "spatial scene busy emitters",
             })
     }
-    pub fn toggle_emitters_sync(enable: bool) {
+    pub fn toggle_sync_emitters(enable: bool) {
         SCENE_SYNC_ENABLED.store(enable, std::sync::atomic::Ordering::SeqCst);
     }
     pub fn register_emitter(

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -140,11 +140,6 @@ impl Plugin for Audioware {
                 c"Audioware.UnregisterEmitter",
                 Engine::unregister_emitter
             )),
-            GlobalExport(global!(c"Audioware.EmittersCount", Engine::emitters_count)),
-            GlobalExport(global!(
-                c"Audioware.IsRegisteredEmitter",
-                Engine::is_registered_emitter
-            )),
             GlobalExport(global!(
                 c"Audioware.DefineSubtitles",
                 Engine::define_subtitles
@@ -160,17 +155,8 @@ impl Plugin for Audioware {
             GlobalExport(global!(c"Audioware.SetPlayerGender", set_player_gender)),
             GlobalExport(global!(c"Audioware.UnsetPlayerGender", unset_player_gender)),
             GlobalExport(global!(c"Audioware.SetGameLocales", set_game_locales)),
-            GlobalExport(global!(
-                c"Audioware.PlayOverThePhone",
-                Engine::play_over_the_phone
-            )),
-            GlobalExport(global!(c"Audioware.Play", Engine::play)),
-            GlobalExport(global!(c"Audioware.Stop", Engine::stop)),
             GlobalExport(global!(c"Audioware.Pause", Engine::pause)),
             GlobalExport(global!(c"Audioware.Resume", Engine::resume)),
-            GlobalExport(global!(c"Audioware.Switch", Engine::switch)),
-            GlobalExport(global!(c"Audioware.PlayOnEmitter", Engine::play_on_emitter)),
-            GlobalExport(global!(c"Audioware.StopOnEmitter", Engine::stop_on_emitter)),
             GlobalExport(global!(c"Audioware.SetReverbMix", Engine::set_reverb_mix)),
             GlobalExport(global!(c"Audioware.SetPreset", Engine::set_preset)),
             GlobalExport(global!(c"Audioware.SetVolume", Engine::set_volume)),

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -114,7 +114,6 @@ impl Plugin for Audioware {
     const VERSION: SemVer = SemVer::new(1, 0, 0);
 
     fn on_init(env: &SdkEnv) {
-        GameState::set(GameState::Load);
         Self::register_listeners(env);
         Self::load_banks(env);
         Self::load_engine(env);
@@ -229,7 +228,7 @@ unsafe extern "C" fn on_exit_initialization(_game: &GameApp) {
 unsafe extern "C" fn on_exit_running(_game: &GameApp) {
     let env = Audioware::env();
     log::info!(env, "on exit running: Audioware");
-    GameState::swap(GameState::Unload);
+    GameState::set(GameState::Unload);
     Engine::shutdown();
 }
 

--- a/audioware/src/states.rs
+++ b/audioware/src/states.rs
@@ -6,15 +6,15 @@ mod player;
 pub trait State {
     type Value: PartialEq + Clone;
     fn swap(value: Self::Value) -> Self::Value;
-    fn set(value: Self::Value) -> Self::Value {
-        Self::swap(value.clone())
+    fn set(value: Self::Value) {
+        Self::swap(value);
     }
     fn get() -> Self::Value;
 }
 
 pub trait ToggleState: State {
     fn set_and_toggle(value: Self::Value) {
-        let prior = Self::set(value.clone());
+        let prior = Self::swap(value.clone());
         Self::toggle(prior, value);
     }
     fn toggle(before: Self::Value, after: Self::Value);

--- a/audioware/src/states/game.rs
+++ b/audioware/src/states/game.rs
@@ -39,8 +39,8 @@ impl State for GameState {
 
 impl ToggleState for GameState {
     fn toggle(before: Self::Value, after: Self::Value) {
-        let before = before.syncable();
-        let after = after.syncable();
+        let before = before.should_sync();
+        let after = after.should_sync();
         if before != after {
             Engine::toggle_sync_emitters(after);
         }
@@ -48,7 +48,7 @@ impl ToggleState for GameState {
 }
 
 impl GameState {
-    pub fn syncable(&self) -> bool {
+    pub fn should_sync(&self) -> bool {
         match self {
             GameState::Load
             | GameState::Menu

--- a/bank/src/ensure.rs
+++ b/bank/src/ensure.rs
@@ -130,7 +130,6 @@ pub fn ensure_located_in_depot(
 }
 
 /// ensure [`Path`](std::path::Path) contains valid audio (based on usage)
-#[inline]
 pub fn ensure_valid_audio(
     path: &impl AsRef<std::path::Path>,
     m: &Mod,


### PR DESCRIPTION
Not completely regressions but the way sounds were handled when pausing / resuming and such left to be desired.
There's still something that could be mistaken for a bug but is inherent to `kira` e.g. if a sound is about to be stopped with a lasting tween of 5 seconds and the player click on pause, then when resuming the game the sound will resume completely, instead of completing its tween and be stopped. Providing a smooth resume in the exact same condition as left when paused would require keeping all states of both tween and sound, which would require much work in the current state of the codebase. In the meantime modders can stop the sound themselves completely on pause, or track the states and resume with existing method (e.g. play on resume followed by stop with tween and remaining time).