### PR TITLE
Unify internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ audioware-bank = { path = "bank" }
 either = "1.13"
 kira = { version = "0.9.4", features = ["serde"] }
 rayon = "1.10"
-red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs", rev = "6ba836a" }
+red4ext-rs = { git = "https://github.com/Roms1383/red4ext-rs", rev = "fe03229" }
+# red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs", rev = "6ba836a" }
 # red4ext-rs-bindings = { git = "https://github.com/jac3km4/red4ext-rs-bindings", rev = "v0.3.0" }
 serde = "1.0"
 snafu = "0.8"

--- a/audioware/reds/Codeware.reds
+++ b/audioware/reds/Codeware.reds
@@ -68,6 +68,6 @@ private func PropagateSubtitle(reaction: CName, entityID: EntityID, emitterName:
         DBG(s"subtitle line about to play");
         let board: ref<IBlackboard> = GameInstance.GetBlackboardSystem(GetGameInstance()).Get(GetAllBlackboardDefs().UIGameData);
         board.SetVariant(GetAllBlackboardDefs().UIGameData.ShowDialogLine, ToVariant([line]), true);
-        AudiowareSystem.GetInstance(GetGameInstance()).DelayHideSubtitle(line, duration);
+        AudioSystemExt.GetInstance(GetGameInstance()).DelayHideSubtitle(line, duration);
     }
 }

--- a/audioware/reds/Ext.reds
+++ b/audioware/reds/Ext.reds
@@ -1,15 +1,6 @@
-import Audioware.AudiowareSystem
-import Audioware.EmitterSettings
-import Audioware.Tween
-import Audioware.AudioSettingsExt
-import Audioware.AudioSettingsExtBuilder
+module Audioware
 
-@addMethod(GameInstance)
-public static func GetAudioSystemExt(game: GameInstance) -> ref<AudioSystemExt> {
-    return new AudioSystemExt();
-}
-
-public native class AudioSystemExt {
+public native class gameAudioSystemExt extends ScriptableSystem {
     // enhanced SDK
     public final native func Play(eventName: CName, opt entityID: EntityID, opt emitterName: CName, opt line: scnDialogLineType, opt ext: ref<AudioSettingsExt>) -> Void;
     public final native func Stop(eventName: CName, opt entityID: EntityID, opt emitterName: CName, opt tween: ref<Tween>) -> Void
@@ -24,9 +15,6 @@ public native class AudioSystemExt {
     }
         
     // spatial scene
-    public final func RegisterEmitter(entityID: EntityID, opt emitterName: CName, opt emitterSettings: EmitterSettings) -> Void { AudiowareSystem.GetInstance(GetGameInstance()).RegisterEmitter(entityID, emitterName, emitterSettings); }
-    public final func UnregisterEmitter(entityID: EntityID) -> Void { AudiowareSystem.GetInstance(GetGameInstance()).UnregisterEmitter(entityID); }
-    public final func IsValidEmitter(className: CName) -> Bool { return AudiowareSystem.GetInstance(GetGameInstance()).IsValidEmitter(className); }
     public final native func IsRegisteredEmitter(entityID: EntityID) -> Bool;
     public final native func EmittersCount() -> Int32;
     public final native func PlayOnEmitter(eventName: CName, entityID: EntityID, emitterName: CName, opt tween: ref<Tween>) -> Void;

--- a/audioware/reds/Orphans.reds
+++ b/audioware/reds/Orphans.reds
@@ -1,0 +1,8 @@
+import Audioware.AudioSystemExt
+
+@addMethod(GameInstance)
+public static func GetAudioSystemExt(game: GameInstance) -> ref<AudioSystemExt> {
+    return GameInstance
+    .GetScriptableSystemsContainer(game)
+    .Get(n"Audioware.AudioSystemExt") as AudioSystemExt;
+}

--- a/audioware/reds/System.reds
+++ b/audioware/reds/System.reds
@@ -1,6 +1,6 @@
 module Audioware
 
-public class AudiowareSystem extends ScriptableSystem {
+public class AudioSystemExt extends gameAudioSystemExt {
     private let attached: ref<CallbackSystemHandler>;
     private let detachedOnce: ref<CallbackSystemHandler>;
     private let attachedOnce: ref<CallbackSystemHandler>;
@@ -16,7 +16,7 @@ public class AudiowareSystem extends ScriptableSystem {
     private let subtitleLine: scnDialogLineData;
 
     private func OnAttach() -> Void {
-        DBG("on attach: AudiowareSystem");
+        DBG("on attach: AudioSystemExt");
         let system: ref<BlackboardSystem> = GameInstance.GetBlackboardSystem(this.GetGameInstance());
         let definitions: ref<AllBlackboardDefinitions> = GetAllBlackboardDefs();
         let ui: ref<IBlackboard> = system.Get(definitions.UI_System);
@@ -53,7 +53,7 @@ public class AudiowareSystem extends ScriptableSystem {
             .SetRunMode(CallbackRunMode.OncePerTarget);
     }
     private func OnDetach() -> Void {
-        DBG("on detach: AudiowareSystem");
+        DBG("on detach: AudioSystemExt");
         this.attached.Unregister();
         this.detachedOnce.Unregister();
         this.attached = null;
@@ -75,7 +75,7 @@ public class AudiowareSystem extends ScriptableSystem {
         }
     }
     private final func OnPlayerAttach(request: ref<PlayerAttachRequest>) -> Void {
-        DBG("on player attach: AudiowareSystem");
+        DBG("on player attach: AudioSystemExt");
         SetGameState(GameState.InGame);
 
         let player = request.owner as PlayerPuppet;
@@ -85,7 +85,7 @@ public class AudiowareSystem extends ScriptableSystem {
         }
     }
     private final func OnPlayerDetach(request: ref<PlayerDetachRequest>) -> Void {
-        DBG("on player detach: AudiowareSystem");
+        DBG("on player detach: AudioSystemExt");
         UnsetPlayerGender();
 
         let player = GameInstance.FindEntityByID(this.GetGameInstance(), request.ownerID) as PlayerPuppet;
@@ -202,7 +202,7 @@ public class AudiowareSystem extends ScriptableSystem {
         let id = entity.GetEntityID();
         let display = EntityID.ToDebugString(id);
         if !entity.IsA(n"PlayerPuppet") {
-            DBG(s"on emitter spawn: AudiowareSystem (\(display))");
+            DBG(s"on emitter spawn: AudioSystemExt (\(display))");
         }
         // ignore EntityTarget placeholder, we only care about emitters here
         if !entity.IsA(n"PlayerPuppet") {
@@ -211,7 +211,7 @@ public class AudiowareSystem extends ScriptableSystem {
                 let registered = RegisterEmitter(id);
                 if registered {
                     this.detachedOnce.AddTarget(EntityTarget.ID(id));
-                    DBG(s"on emitter registered: AudiowareSystem (\(display))");
+                    DBG(s"on emitter registered: AudioSystemExt (\(display))");
                 }
             }
         }
@@ -223,18 +223,18 @@ public class AudiowareSystem extends ScriptableSystem {
         if !entity.IsA(n"PlayerPuppet") {
             let id = entity.GetEntityID();
             let display = EntityID.ToDebugString(id);
-            DBG(s"on emitter despawn: AudiowareSystem (\(display))");
+            DBG(s"on emitter despawn: AudioSystemExt (\(display))");
             let registered = GameInstance.GetAudioSystemExt(this.GetGameInstance()).IsRegisteredEmitter(id);
             if registered {
-                DBG(s"on emitter despawn while registered: AudiowareSystem (\(display))");
+                DBG(s"on emitter despawn while registered: AudioSystemExt (\(display))");
                 let unregistered = UnregisterEmitter(id);
-                DBG(s"on emitter despawn + unregistered?[\(ToString(unregistered))]: AudiowareSystem (\(display))");
+                DBG(s"on emitter despawn + unregistered?[\(ToString(unregistered))]: AudioSystemExt (\(display))");
             }
-        } else { DBG("on player despawn: AudiowareSystem"); }
+        } else { DBG("on player despawn: AudioSystemExt"); }
     }
 
     protected cb func OnInMenu(value: Bool) -> Bool {
-        DBG(s"on \(value ? "enter" : "exit") menu: AudiowareSystem");
+        DBG(s"on \(value ? "enter" : "exit") menu: AudioSystemExt");
         SetGameState(value ? GameState.InMenu : GameState.InGame);
         if value {
             Pause();
@@ -245,12 +245,12 @@ public class AudiowareSystem extends ScriptableSystem {
         }
     }
     protected cb func OnPlayerReverb(value: Float) -> Bool {
-        DBG(s"on reverb mix changed (\(ToString(value))): AudiowareSystem");
+        DBG(s"on reverb mix changed (\(ToString(value))): AudioSystemExt");
         SetReverbMix(value);
     }
     protected cb func OnPlayerPreset(value: Int32) -> Bool {
         let preset = IntEnum<Preset>(value);
-        DBG(s"on player preset changed (\(ToString(preset))): AudiowareSystem");
+        DBG(s"on player preset changed (\(ToString(preset))): AudioSystemExt");
         SetPreset(preset);
     }
     protected cb func OnSwim(value: Int32) -> Bool {
@@ -259,10 +259,10 @@ public class AudiowareSystem extends ScriptableSystem {
         SetPreset(diving ? Preset.Underwater : Preset.None);
     }
 
-    public final static func GetInstance(game: GameInstance) -> ref<AudiowareSystem> {
+    public final static func GetInstance(game: GameInstance) -> ref<AudioSystemExt> {
         return GameInstance
         .GetScriptableSystemsContainer(game)
-        .Get(n"Audioware.AudiowareSystem") as AudiowareSystem;
+        .Get(n"Audioware.AudioSystemExt") as AudioSystemExt;
     }
 }
 
@@ -273,7 +273,7 @@ public class HideSubtitleCallback extends DelayCallback {
         let game = this.line.speaker.GetGame();
         GameInstance
         .GetDelaySystem(game)
-        .CancelCallback(AudiowareSystem.GetInstance(game).subtitleDelayID);
+        .CancelCallback(AudioSystemExt.GetInstance(game).subtitleDelayID);
         let board: ref<IBlackboard> = GameInstance.GetBlackboardSystem(game).Get(GetAllBlackboardDefs().UIGameData);
         board.SetVariant(GetAllBlackboardDefs().UIGameData.HideDialogLine, [this.line.id], true);
     }

--- a/audioware/src/ext.rs
+++ b/audioware/src/ext.rs
@@ -3,7 +3,7 @@ use kira::sound::PlaybackPosition;
 use red4ext_rs::{
     class_kind::Native,
     log,
-    types::{CName, EntityId, IScriptable, Opt, Ref},
+    types::{CName, EntityId, Opt, Ref, ScriptableSystem},
     PluginOps, ScriptClass,
 };
 
@@ -15,16 +15,16 @@ use crate::{
 
 #[derive(Debug, Default, Clone)]
 #[repr(C)]
-pub struct AudioSystemExt {
-    base: IScriptable,
+pub struct GameAudioSystemExt {
+    base: ScriptableSystem,
 }
 
-unsafe impl ScriptClass for AudioSystemExt {
+unsafe impl ScriptClass for GameAudioSystemExt {
     type Kind = Native;
-    const NAME: &'static str = "AudioSystemExt";
+    const NAME: &'static str = "Audioware.gameAudioSystemExt";
 }
 
-impl AudioSystemExt {
+impl GameAudioSystemExt {
     pub fn play(
         &self,
         sound_name: CName,

--- a/audioware/src/lib.rs
+++ b/audioware/src/lib.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 use audioware_bank::{Banks, Initialization};
 use audioware_manifest::{PlayerGender, SpokenLocale, WrittenLocale};
 use engine::{AudioRegion, AudioSettingsExt, AudioSettingsExtBuilder, Engine};
-use ext::AudioSystemExt;
+use ext::GameAudioSystemExt;
 use hooks::*;
 use red4ext_rs::{
     call, export_plugin_symbols, exports, global, log, methods, static_methods,
-    types::{CName, GameEngine, IScriptable, Opt, RedArray, RedString},
+    types::{CName, GameEngine, IScriptable, Opt, RedArray, RedString, ScriptableSystem},
     wcstr, ClassExport, Exportable, GameApp, GlobalExport, Plugin, PluginOps, RttiRegistrator,
     RttiSystem, ScriptClass, SdkEnv, SemVer, StateListener, U16CStr,
 };
@@ -185,18 +185,18 @@ impl Plugin for Audioware {
             GlobalExport(global!(c"Audioware.SetReverbMix", Engine::set_reverb_mix)),
             GlobalExport(global!(c"Audioware.SetPreset", Engine::set_preset)),
             GlobalExport(global!(c"Audioware.SetVolume", Engine::set_volume)),
-            ClassExport::<AudioSystemExt>::builder()
-                .base(IScriptable::NAME)
+            ClassExport::<GameAudioSystemExt>::builder()
+                .base(ScriptableSystem::NAME)
                 .methods(methods![
-                    final c"Play" => AudioSystemExt::play,
-                    final c"Stop" => AudioSystemExt::stop,
-                    final c"Switch" => AudioSystemExt::switch,
-                    final c"PlayOverThePhone" => AudioSystemExt::play_over_the_phone,
-                    final c"IsRegisteredEmitter" => AudioSystemExt::is_registered_emitter,
-                    final c"EmittersCount" => AudioSystemExt::emitters_count,
-                    final c"PlayOnEmitter" => AudioSystemExt::play_on_emitter,
-                    final c"StopOnEmitter" => AudioSystemExt::stop_on_emitter,
-                    final c"OnEmitterDies" => AudioSystemExt::on_emitter_dies,
+                    final c"Play" => GameAudioSystemExt::play,
+                    final c"Stop" => GameAudioSystemExt::stop,
+                    final c"Switch" => GameAudioSystemExt::switch,
+                    final c"PlayOverThePhone" => GameAudioSystemExt::play_over_the_phone,
+                    final c"IsRegisteredEmitter" => GameAudioSystemExt::is_registered_emitter,
+                    final c"EmittersCount" => GameAudioSystemExt::emitters_count,
+                    final c"PlayOnEmitter" => GameAudioSystemExt::play_on_emitter,
+                    final c"StopOnEmitter" => GameAudioSystemExt::stop_on_emitter,
+                    final c"OnEmitterDies" => GameAudioSystemExt::on_emitter_dies,
                 ])
                 .build(),
             ClassExport::<AudioRegion>::builder()


### PR DESCRIPTION
Unify internal systems if possible.

Currently on commit 287df87 it crashes on launch, slightly after Cyberpunk logo (rtti registration I'd say).

![Screenshot 2024-08-19 145134](https://github.com/user-attachments/assets/2e49d049-de42-4df5-b170-f12714d5a087)

### requirements
- Redscript `0.25.5`
- Codeware `1.12.3`
- TweakXL `1.10.4`
- CET `1.32.3`

### audio
Since I cannot distribute sample audio without artists consent, fastest way to test is to create `mods/TestAudioware/bank.yml` like so:
```yml
version: 1.0.0
music:
    my_music: my-music.mp3 # your own song here
```
a short Redscript snippet:
```swift
public static exec func TestAudiowarePlay(game: GameInstance) {
    GameInstance.GetAudioSystemExt(game).Play(n"my_music");
}
```
and test it in CET console:
```lua
Game.TestAudiowarePlay();
```