### PR TITLE
Subtitle regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["manifest", "bank", "audioware", "core"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.80.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ audioware-core = { path = "core" }
 audioware-manifest = { path = "manifest" }
 audioware-bank = { path = "bank" }
 either = "1.13"
-kira = { version = "0.9.4", features = ["serde"] }
+glam = "0.29"
+kira = { version = "0.9.5", features = ["serde"] }
 rayon = "1.10"
 red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs", rev = "d6b2976" }
 # red4ext-rs-bindings = { git = "https://github.com/jac3km4/red4ext-rs-bindings", rev = "v0.3.0" }

--- a/audioware/Cargo.toml
+++ b/audioware/Cargo.toml
@@ -19,7 +19,7 @@ cpal = "0.15"
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dashmap = { version = "6.0", features = ["inline", "rayon"] }
 either.workspace = true
-glam = { version = "0.28", features = ["mint"] }
+glam = { workspace = true, features = ["mint"] }
 kira.workspace = true
 mint = { version = "0.5" }
 once_cell = "1.19"

--- a/bank/src/ensure.rs
+++ b/bank/src/ensure.rs
@@ -490,10 +490,10 @@ pub fn ensure_voice<'a>(
         Either::Left((aud, usage, subs)) => {
             for (locale, Audio { file, settings }) in aud {
                 simple_key = LocaleKey(cname, locale);
-                if let Some(ref subs) = subs {
+                if let Some(subs) = subs.as_ref().and_then(|x| x.get(&locale)) {
                     ensure_store_subtitle::<LocaleKey>(
                         simple_key.clone(),
-                        subs.get(&locale).unwrap().clone(),
+                        subs.clone(),
                         simple_subs,
                     )?;
                 }
@@ -515,10 +515,14 @@ pub fn ensure_voice<'a>(
             for (locale, genders) in aud {
                 for (gender, Audio { file, settings }) in genders {
                     complex_key = BothKey(cname, locale, gender);
-                    if let Some(ref subs) = subs {
+                    if let Some(subs) = subs.as_ref().and_then(|x| x.get(&locale)) {
                         ensure_store_subtitle::<BothKey>(
                             complex_key.clone(),
-                            subs.get(&locale).unwrap().get(&gender).unwrap().clone(),
+                            if gender == PlayerGender::Female {
+                                subs.female.clone()
+                            } else {
+                                subs.male.clone()
+                            },
                             complex_subs,
                         )?;
                     }

--- a/manifest/src/de/voice.rs
+++ b/manifest/src/de/voice.rs
@@ -327,6 +327,29 @@ mod tests {
             settings:
                 region:
                     starts: 300ms"## ; "dual dialog with different subtitles, default line and custom settings")]
+        #[test_case(r##"id:
+    en-us:
+      fem: some.mp3
+      male: another.mp3
+      subtitle: "Shared subtitle!"
+    settings:
+      region:
+        starts: 1s
+    usage: streaming"## ; "dual dialog with shared subtitle, default line, custom usage and setting")]
+        #[test_case(r##"id:
+    en-us:
+      fem: ./nested/fem_intro.mp3
+      male: ./nested/male_intro.mp3
+      subtitle: "Yadi yada."
+    usage: streaming"## ; "dual dialog with shared subtitle, default line and setting but custom usage")]
+        #[test_case(r##"id:
+    en-us:
+      fem:
+        file: ./thai/fem_intro.mp3
+        subtitle: "hi friend!"
+      male:
+        file: ./thai/male_intro.mp3
+        subtitle: "heya""## ; "dual dialog with different subtitles")]
         fn basic_format_with_subtitles(yaml: &str) {
             let dual_dialog = serde_yaml::from_str::<HashMap<String, Voice>>(yaml);
             dbg!("{}", &dual_dialog);

--- a/manifest/src/de/voice.rs
+++ b/manifest/src/de/voice.rs
@@ -12,12 +12,6 @@ use super::{paths_into_audios, Audio, DialogLine, GenderBased, Settings, Usage};
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Voice {
-    SingleInline {
-        #[serde(flatten)]
-        dialogs: HashMap<Locale, PathBuf>,
-        usage: Option<Usage>,
-        settings: Option<Settings>,
-    },
     SingleMulti {
         #[serde(flatten)]
         dialogs: HashMap<Locale, Dialog>,
@@ -25,9 +19,9 @@ pub enum Voice {
         line: Option<ScnDialogLineType>,
         settings: Option<Settings>,
     },
-    DualInline {
+    SingleInline {
         #[serde(flatten)]
-        dialogs: HashMap<Locale, GenderBased<PathBuf>>,
+        dialogs: HashMap<Locale, PathBuf>,
         usage: Option<Usage>,
         settings: Option<Settings>,
     },
@@ -36,6 +30,12 @@ pub enum Voice {
         dialogs: HashMap<Locale, Dialogs>,
         usage: Option<Usage>,
         line: Option<ScnDialogLineType>,
+        settings: Option<Settings>,
+    },
+    DualInline {
+        #[serde(flatten)]
+        dialogs: HashMap<Locale, GenderBased<PathBuf>>,
+        usage: Option<Usage>,
         settings: Option<Settings>,
     },
 }


### PR DESCRIPTION
There's a regression reported by @misterchedda concerning subtitles defined in `voices` with / without custom `usage`.

It happens that `serde` will take the very first variant that matches a complex enum and picked the wrong one, completely omitting `subtitle` in the process.