### PR TITLE
Fix volume after switch from amplitude to decibels

### DIFF
--- a/crates/audioware/reds/Debug.reds
+++ b/crates/audioware/reds/Debug.reds
@@ -226,3 +226,18 @@ public static exec func TestPreset(game: GameInstance, preset: String) {
     .Get(GetAllBlackboardDefs().Audioware_Settings)
     .SetInt(GetAllBlackboardDefs().Audioware_Settings.AudioPreset, value, true);
 }
+
+public static exec func TestHalfVolume(game: GameInstance) = TestSpecificVolume(game, 0.5);
+public static exec func TestDoubleVolume(game: GameInstance) = TestSpecificVolume(game, 2.0);
+public static exec func TestNormalVolume(game: GameInstance) = TestSpecificVolume(game, 1.0);
+
+public static exec func TestSpecificVolume(game: GameInstance, amplitude: Float) {
+    let none: EntityID;
+    let ext = new AudioSettingsExt();
+    ext.volume = amplitude;
+    GameInstance.GetAudioSystemExt(game).Play(n"straight_outta_compton", none, n"None", scnDialogLineType.None, ext);
+}
+
+public static exec func StopTestVolume(game: GameInstance) {
+    GameInstance.GetAudioSystemExt(game).Stop(n"straight_outta_compton");
+}

--- a/crates/audioware/reds/Debug.reds
+++ b/crates/audioware/reds/Debug.reds
@@ -227,9 +227,9 @@ public static exec func TestPreset(game: GameInstance, preset: String) {
     .SetInt(GetAllBlackboardDefs().Audioware_Settings.AudioPreset, value, true);
 }
 
-public static exec func TestHalfVolume(game: GameInstance) = TestSpecificVolume(game, 0.5);
-public static exec func TestDoubleVolume(game: GameInstance) = TestSpecificVolume(game, 2.0);
-public static exec func TestNormalVolume(game: GameInstance) = TestSpecificVolume(game, 1.0);
+public static exec func TestHalfVolume(game: GameInstance)   { TestSpecificVolume(game, 0.5); }
+public static exec func TestDoubleVolume(game: GameInstance) { TestSpecificVolume(game, 2.0); }
+public static exec func TestNormalVolume(game: GameInstance) { TestSpecificVolume(game, 1.0); }
 
 public static exec func TestSpecificVolume(game: GameInstance, amplitude: Float) {
     let none: EntityID;

--- a/crates/audioware/src/abi/types.rs
+++ b/crates/audioware/src/abi/types.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use audioware_core::SpatialTrackSettings;
+use audioware_core::{Amplitude, SpatialTrackSettings};
 use audioware_manifest::{Interpolation, Locale, LocaleExt, PlayerGender, Region, Settings};
 use kira::{backend::cpal::CpalBackend, track::SpatialTrackDistances, Easing};
 use red4ext_rs::{
@@ -209,12 +209,16 @@ impl ToSettings for AudioSettingsExt {
             fails!("invalid start position: {e}");
             return None;
         }
+        let Ok(volume) = Amplitude::try_from(self.volume) else {
+            fails!("invalid volume ({})", self.volume);
+            return None;
+        };
         Some(Settings {
             start_time: Default::default(),
             start_position: Some(Duration::from_secs_f32(self.start_position)),
             region: self.region.into_region(),
             r#loop: Some(self.r#loop),
-            volume: Some(self.volume),
+            volume: Some(volume),
             fade_in_tween: self.fade_in.into_interpolation(),
             panning: Some(self.panning),
             playback_rate: Some(kira::PlaybackRate(self.playback_rate as f64)),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,3 +8,6 @@ rust-version.workspace = true
 kira.workspace = true
 serde.workspace = true
 snafu.workspace = true
+
+[dev-dependencies]
+test-case = "3.3"

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -58,7 +58,7 @@ macro_rules! impl_audio_settings {
 
             #[inline]
             fn volume(&self) -> ::kira::Value<::kira::Decibels> {
-                self.volume.clone()
+                self.volume
             }
 
             #[inline]


### PR DESCRIPTION
This PR fixes amplitude to decibels conversions and usage.

However, since `kira` switched from amplitude to decibels, it does not sound quite right when audio is made louder.
It could be related to [this issue](https://github.com/tesselode/kira/issues/132) even though the conversion is unit-tested and on-par with [kira's Decibels tests](https://github.com/tesselode/kira/blob/805d4a5d9133855701a0da48df496049f8f647b9/crates/kira/src/decibels.rs#L97-L118):
```rs
#[cfg(test)]
mod tests {
    use kira::Decibels;
    use test_case::test_case;

    use crate::Amplitude;

    #[test_case(0.0, Decibels::SILENCE ; "silence")]
    #[test_case(0.25118864, Decibels(-12.) ; "minus 12dB")]
    #[test_case(0.70794576, Decibels(-3.) ; "minus 3dB")]
    #[test_case(1.0, Decibels::IDENTITY ; "identity")]
    #[test_case(1.4125376, Decibels(3.0) ; "plus 3dB")]
    #[test_case(3.9810717, Decibels(12.0) ; "plus 12dB")]
    fn amplitude_as_decibels(given: f32, expected: Decibels) {
        assert_eq!(amplitude!(given).as_decibels(), expected);
    }
}
```
Waiting to see how it evolves upstream first.