### PR TITLE
Ignore UI Menu event when pre-game

### DIFF
--- a/crates/audioware/reds/Natives.reds
+++ b/crates/audioware/reds/Natives.reds
@@ -22,6 +22,7 @@ private native func OnGameSystemPlayerDetach();
 private native func OnGameSystemDetach();
 
 private native func OnUIMenu(value: Bool);
+private native func OnEngagementScreen();
 
 private native func SetVolume(setting: CName, value: Float);
 private native func SetReverbMix(value: Float) -> Void;

--- a/crates/audioware/reds/PreGame.reds
+++ b/crates/audioware/reds/PreGame.reds
@@ -1,0 +1,7 @@
+module Audioware
+
+@wrapMethod(MenuScenario_PreGameSubMenu)
+protected cb func OnSwitchToEngagementScreen() -> Bool {
+    OnEngagementScreen();
+    return wrappedMethod();
+}

--- a/crates/audioware/src/abi/lifecycle.rs
+++ b/crates/audioware/src/abi/lifecycle.rs
@@ -60,6 +60,8 @@ pub enum Lifecycle {
         ease_out_curve: CName,
     },
     Session(Session),
+    EngagementScreen,
+    LoadSave,
     System(System),
     Board(Board),
     ReportInitialization,
@@ -87,6 +89,8 @@ impl std::fmt::Display for Lifecycle {
             }
             Lifecycle::Terminate => write!(f, "terminate"),
             Lifecycle::Session(x) => write!(f, "{x}"),
+            Lifecycle::EngagementScreen => write!(f, "on switch to engagement screen"),
+            Lifecycle::LoadSave => write!(f, "on load save"),
             Lifecycle::System(x) => write!(f, "{x}"),
             Lifecycle::Board(x) => write!(f, "{x}"),
             Lifecycle::SetVolume { setting, value } => {

--- a/crates/audioware/src/abi/mod.rs
+++ b/crates/audioware/src/abi/mod.rs
@@ -79,6 +79,7 @@ pub fn exports() -> impl Exportable {
         g!(c"Audioware.OnGameSystemDetach",         Audioware::on_game_system_detach),
         g!(c"Audioware.OnGameSystemPlayerAttach",   Audioware::on_game_system_player_attach),
         g!(c"Audioware.OnGameSystemPlayerDetach",   Audioware::on_game_system_player_detach),
+        g!(c"Audioware.OnEngagementScreen",         Audioware::on_engagement_screen),
         g!(c"Audioware.OnUIMenu",                   Audioware::on_ui_menu),
         g!(c"Audioware.SetReverbMix",               Audioware::on_reverb_mix),
         g!(c"Audioware.SetPreset",                  Audioware::on_preset),
@@ -122,6 +123,7 @@ pub trait GameSessionLifecycle {
     fn on_game_session_resume();
     fn on_game_session_before_end();
     fn on_game_session_end();
+    fn on_engagement_screen();
 }
 
 pub trait GameSystemLifecycle {
@@ -176,6 +178,10 @@ impl GameSessionLifecycle for Audioware {
 
     fn on_game_session_end() {
         queue::notify(Lifecycle::Session(Session::End));
+    }
+
+    fn on_engagement_screen() {
+        queue::notify(Lifecycle::EngagementScreen);
     }
 }
 

--- a/crates/audioware/src/hooks/mod.rs
+++ b/crates/audioware/src/hooks/mod.rs
@@ -17,7 +17,6 @@ pub fn attach(env: &SdkEnv) {
     time_dilatable::attach_hooks(env);
     time_system::attach_hooks(env);
 
-    #[cfg(debug_assertions)]
     save_handling_controller::attach_hook(env);
     #[cfg(debug_assertions)]
     entity::attach_hook(env);

--- a/crates/audioware/src/hooks/save_handling_controller.rs
+++ b/crates/audioware/src/hooks/save_handling_controller.rs
@@ -3,7 +3,7 @@ use red4ext_rs::{
     types::{IScriptable, StackFrame},
 };
 
-use crate::{attach_native_func, utils::intercept};
+use crate::{abi::lifecycle::Lifecycle, attach_native_func, engine::queue, utils::intercept};
 
 attach_native_func!(
     "gameuiSaveHandlingController::LoadSaveInGame/LoadModdedSave",
@@ -24,6 +24,7 @@ unsafe extern "C" fn detour(
         let save_id: i32 = StackFrame::get_arg(frame);
         frame.restore_args(state);
         intercept!("gameuiSaveHandlingController::LoadSaveInGame/LoadModdedSave: {save_id}");
+        queue::notify(Lifecycle::LoadSave);
         cb(i, frame as *mut _, a3, a4);
     }
 }


### PR DESCRIPTION
Allow for smoother intro music by ignoring UI Menu events _only while pre-game_ and fading-out audio on load save.

- [ ] check with new save
- [ ] check multiple loadings / in-game / back to main-menu to ensure no regression in sound management