### PR TITLE
Fix music running in benchmark

### DIFF
--- a/crates/audioware/reds/Controller.reds
+++ b/crates/audioware/reds/Controller.reds
@@ -1,0 +1,23 @@
+module Audioware
+
+@wrapMethod(SettingsMainGameController)
+protected cb func OnButtonRelease(evt: ref<inkPointerEvent>) -> Bool {
+    if evt.IsAction(n"run_benchmark") && this.IsBenchmarkPossible() && inkWidgetRef.IsVisible(this.m_benchmarkButton) {
+        SetInBenchmark(true);
+    }
+    return wrappedMethod(evt);
+}
+
+@wrapMethod(SettingsMainGameController)
+protected cb func OnBenchmarkButtonReleased(controller: wref<inkButtonController>) -> Bool {
+    if this.IsBenchmarkPossible() {
+        SetInBenchmark(true);
+    }
+    return wrappedMethod(controller);
+}
+
+@wrapMethod(MenuScenario_BenchmarkResults)
+protected cb func OnBenchmarkResultsClose() -> Bool {
+    SetInBenchmark(false);
+    return wrappedMethod();
+}

--- a/crates/audioware/reds/Natives.reds
+++ b/crates/audioware/reds/Natives.reds
@@ -26,6 +26,7 @@ private native func OnEngagementScreen();
 
 private native func SetVolume(setting: CName, value: Float);
 private native func SetMuteInBackground(value: Bool);
+private native func SetInBenchmark(value: Bool);
 private native func SetReverbMix(value: Float) -> Void;
 private native func SetPreset(value: Preset) -> Void;
 private native func SetPlayerGender(value: PlayerGender) -> Void;

--- a/crates/audioware/src/abi/lifecycle.rs
+++ b/crates/audioware/src/abi/lifecycle.rs
@@ -43,6 +43,9 @@ pub enum Lifecycle {
     SetMuteInBackground {
         value: bool,
     },
+    SetInBenchmark {
+        value: bool,
+    },
     SetListenerDilation {
         value: f32,
         reason: CName,
@@ -109,6 +112,9 @@ impl std::fmt::Display for Lifecycle {
             }
             Lifecycle::SetMuteInBackground { value } => {
                 write!(f, "set mute in background {value}")
+            }
+            Lifecycle::SetInBenchmark { value } => {
+                write!(f, "set in benchmark {value}")
             }
             Lifecycle::SetListenerDilation {
                 value: dilation,

--- a/crates/audioware/src/abi/mod.rs
+++ b/crates/audioware/src/abi/mod.rs
@@ -101,6 +101,7 @@ pub fn exports() -> impl Exportable {
         g!(c"Audioware.SetPreset",                  Audioware::on_preset),
         g!(c"Audioware.SetVolume",                  Audioware::set_volume),
         g!(c"Audioware.SetMuteInBackground",        Audioware::set_mute_in_background),
+        g!(c"Audioware.SetInBenchmark",             Audioware::set_in_benchmark),
         g!(c"Audioware.SetPlayerGender",            Audioware::set_player_gender),
         g!(c"Audioware.UnsetPlayerGender",          Audioware::unset_player_gender),
         g!(c"Audioware.SetGameLocales",             Audioware::set_game_locales),
@@ -167,6 +168,7 @@ pub trait CodewareLifecycle {
 pub trait ListenerLifecycle {
     fn set_volume(setting: CName, value: f32);
     fn set_mute_in_background(value: bool);
+    fn set_in_benchmark(value: bool);
 }
 
 impl GameSessionLifecycle for Audioware {
@@ -246,6 +248,10 @@ impl ListenerLifecycle for Audioware {
 
     fn set_mute_in_background(value: bool) {
         queue::notify(Lifecycle::SetMuteInBackground { value });
+    }
+
+    fn set_in_benchmark(value: bool) {
+        queue::notify(Lifecycle::SetInBenchmark { value });
     }
 }
 


### PR DESCRIPTION
As reported by Giever, audioware keeps running during benchmarks run.
For now engine won't be completely shut as it could potentially lead to more bugs, but sync / reclamation skipped and sound(s) paused / then resumed once finished.