### PR TITLE
Fixes for dialog lipsync

### DIFF
--- a/crates/audioware/src/hooks/audio.rs
+++ b/crates/audioware/src/hooks/audio.rs
@@ -1,5 +1,6 @@
 use std::ops::Not;
 
+use audioware_bank::error::registry::ErrorDisplay;
 use kira::backend::cpal::CpalBackend;
 use red4ext_rs::{
     VoidPtr,
@@ -64,40 +65,43 @@ unsafe extern "C" fn detour(
         let expression = data.expression;
         let seek_time = data.seek_time;
         let playback_speed_parameter = data.playback_speed_parameter;
-        crate::utils::intercept!(
-            "audio::PlayDialogLine
-    - data.string_id: {string_id:?}
-    - data.is_player: {is_player}
-    - data.is_holocall: {is_holocall}
-    - data.is_rewind: {is_rewind}
-    - data.context: {context}
-    - data.expression: {expression}
-    - data.seek_time: {seek_time}
-    - data.playback_speed_parameter: {playback_speed_parameter}
-    - data.custom_vo_event: {}
-    - entity_id: {a3:?}
-    - has_helmet: {a5:?}
-    - played_speech_line: {}
-    - playback_speed: {}
-    - has_helmet: {a5}
-    - vo_event_override: {}
-    - played_vo_event: {}
-    - tag_event: {}",
-            data.custom_vo_event.as_str(),
-            if a6.is_null().not() {
-                *a6
-            } else {
-                Default::default()
-            },
-            a8,
-            a4.as_str(),
-            if a7.is_null().not() {
-                (*a7).as_str()
-            } else {
-                ""
-            },
-            a9.as_str()
-        );
+        if a7.is_null() || (*a7).as_str() != "vo_global_tv" {
+            crate::utils::intercept!(
+                "audio::PlayDialogLine
+        - data.string_id: {}
+        - data.is_player: {is_player}
+        - data.is_holocall: {is_holocall}
+        - data.is_rewind: {is_rewind}
+        - data.context: {context}
+        - data.expression: {expression}
+        - data.seek_time: {seek_time}
+        - data.playback_speed_parameter: {playback_speed_parameter}
+        - data.custom_vo_event: {}
+        - entity_id: {a3:?}
+        - has_helmet: {a5:?}
+        - played_speech_line: {}
+        - playback_speed: {}
+        - has_helmet: {a5}
+        - vo_event_override: {}
+        - played_vo_event: {}
+        - tag_event: {}",
+                string_id.error_display(),
+                data.custom_vo_event.as_str(),
+                if a6.is_null().not() {
+                    *a6
+                } else {
+                    Default::default()
+                },
+                a8,
+                a4.as_str(),
+                if a7.is_null().not() {
+                    (*a7).as_str()
+                } else {
+                    ""
+                },
+                a9.as_str()
+            );
+        }
         let modded = Engine::<CpalBackend>::exists_for_scene(&string_id);
         if Engine::<CpalBackend>::exists_for_scene(&string_id) {
             crate::engine::queue::send(Command::PlaySceneDialog {

--- a/crates/audioware/src/hooks/events/dialog_line.rs
+++ b/crates/audioware/src/hooks/events/dialog_line.rs
@@ -1,6 +1,7 @@
 use red4ext_rs::{ScriptClass, types::IScriptable};
 
 use crate::{DialogLine, DialogLineEventData, Entity, attach_native_event};
+use audioware_bank::error::registry::ErrorDisplay;
 
 attach_native_event!(super::super::offsets::EVENT_DIALOGLINE, crate::DialogLine);
 
@@ -33,7 +34,7 @@ unsafe extern "C" fn detour(
             .map(|x| x.entity_id);
         crate::utils::lifecycle!(
             "intercepted {} on {classname} ({id:?}):
-- data.string_id {string_id:?}
+- data.string_id {}
 - data.context {context}
 - data.expression {expression}
 - data.is_player {is_player}
@@ -42,7 +43,8 @@ unsafe extern "C" fn detour(
 - data.custom_vo_event {custom_vo_event}
 - data.seek_time {seek_time}
 - data.playback_speed_parameter {playback_speed_parameter}",
-            DialogLine::NAME
+            DialogLine::NAME,
+            string_id.error_display()
         );
         cb(a1, a2);
     }

--- a/crates/audioware/src/hooks/mod.rs
+++ b/crates/audioware/src/hooks/mod.rs
@@ -21,7 +21,6 @@ mod script_audio_player;
 mod events;
 
 pub fn attach(env: &SdkEnv) {
-    vo::attach_hook(env);
     sound_component::attach_hook(env);
     audio::attach_hook(env);
     audio_system::attach_hooks(env);

--- a/crates/audioware/src/hooks/mod.rs
+++ b/crates/audioware/src/hooks/mod.rs
@@ -7,6 +7,7 @@ mod onscreen_vo;
 mod sound_component;
 mod time_dilatable;
 mod time_system;
+mod vo;
 
 #[cfg(debug_assertions)]
 mod entity;
@@ -20,6 +21,7 @@ mod script_audio_player;
 mod events;
 
 pub fn attach(env: &SdkEnv) {
+    vo::attach_hook(env);
     sound_component::attach_hook(env);
     audio::attach_hook(env);
     audio_system::attach_hooks(env);
@@ -56,6 +58,7 @@ pub fn attach(env: &SdkEnv) {
 #[doc(hidden)]
 mod offsets {
     pub const AUDIO_PLAY_DIALOG_LINE: u32                       = 0x28F53A76;   // 0x1405FC310 (2.3)
+    pub const VO_STORAGE_GET_VO_FILE: u32                       = 0x899C28D0;   // 0x140A93F84 (2.31)
     pub const AUDIOSYSTEM_PLAY: u32                             = 0xCDB11D0E;   // 0x140974F58 (2.12a)
     pub const AUDIOSYSTEM_STOP: u32                             = 0xD2781D1E;   // 0x1424503F8 (2.12a)
     pub const AUDIOSYSTEM_SWITCH: u32                           = 0x15081DEA;   // 0x140291688 (2.12a)

--- a/crates/audioware/src/hooks/vo.rs
+++ b/crates/audioware/src/hooks/vo.rs
@@ -1,0 +1,98 @@
+use audioware_bank::error::registry::ErrorDisplay;
+use red4ext_rs::VoidPtr;
+use red4ext_rs::types::{Cruid, RaRef};
+
+::red4ext_rs::hooks! {
+    static HOOK: fn(
+    a1: VoidPtr,
+    a2: VoType,
+    a3: *const Cruid,
+    a4: VoidPtr,
+    a5: *mut RaRef<()>) -> VoFileResult;
+}
+
+#[allow(clippy::missing_transmute_annotations)]
+pub fn attach_hook(env: &::red4ext_rs::SdkEnv) {
+    let addr = ::red4ext_rs::addr_hashes::resolve(super::offsets::VO_STORAGE_GET_VO_FILE);
+    let addr = unsafe { ::std::mem::transmute(addr) };
+    unsafe { env.attach_hook(HOOK, addr, detour) };
+    crate::utils::intercept!(
+        "attached native internal hook for vo::GetVoFile( VoType, &CRUID, x, &RaRef ) -> VoFileResult"
+    );
+}
+
+unsafe extern "C" fn detour(
+    a1: VoidPtr,
+    a2: VoType,
+    a3: *const Cruid,
+    a4: VoidPtr,
+    a5: *mut RaRef<()>,
+    cb: unsafe extern "C" fn(
+        a1: VoidPtr,
+        a2: VoType,
+        a3: *const Cruid,
+        a4: VoidPtr,
+        a5: *mut RaRef<()>,
+    ) -> VoFileResult,
+) -> VoFileResult {
+    unsafe {
+        let outcome = cb(a1, a2, a3, a4, a5);
+        crate::utils::lifecycle!(
+            "vo::GetVoFile( {a2}, {}, x, x) -> {outcome}",
+            (&*a3).error_display()
+        );
+        outcome
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+#[allow(clippy::enum_variant_names, dead_code)]
+pub enum VoFileResult {
+    NoFileFound = 0,
+    RecordedFileFound = 1,
+    GeneratedFileFound = 2,
+    GeneratedFallbackVariantFileFound = 3,
+    CommonStorageFileFound = 4,
+}
+
+impl std::fmt::Display for VoFileResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::NoFileFound => "NoFileFound",
+                Self::RecordedFileFound => "RecordedFileFound",
+                Self::GeneratedFileFound => "GeneratedFileFound",
+                Self::GeneratedFallbackVariantFileFound => "GeneratedFallbackVariantFileFound",
+                Self::CommonStorageFileFound => "CommonStorageFileFound",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(i32)]
+#[allow(dead_code)]
+pub enum VoType {
+    Standard = 0,
+    Rewind = 1,
+    Helmet = 2,
+    Holocall = 3,
+}
+
+impl std::fmt::Display for VoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Standard => "Standard",
+                Self::Rewind => "Rewind",
+                Self::Helmet => "Helmet",
+                Self::Holocall => "Holocall",
+            }
+        )
+    }
+}

--- a/crates/audioware/src/hooks/vo.rs
+++ b/crates/audioware/src/hooks/vo.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use audioware_bank::error::registry::ErrorDisplay;
 use red4ext_rs::VoidPtr;
 use red4ext_rs::types::{Cruid, RaRef};

--- a/crates/core/src/data/static.rs
+++ b/crates/core/src/data/static.rs
@@ -50,16 +50,13 @@ impl With<SceneDialogSettings> for StaticSoundData {
     where
         Self: Sized,
     {
-        if settings.is_rewind {
-            return self.start_position(match self.settings.start_position {
-                PlaybackPosition::Seconds(x) => {
-                    PlaybackPosition::Seconds(x + settings.seek_time as f64)
-                }
-                PlaybackPosition::Samples(x) => PlaybackPosition::Samples(
-                    x + (settings.seek_time * self.sample_rate as f32) as usize,
-                ),
-            });
-        }
-        self
+        self.start_position(match self.settings.start_position {
+            PlaybackPosition::Seconds(x) => {
+                PlaybackPosition::Seconds(x + settings.seek_time as f64)
+            }
+            PlaybackPosition::Samples(x) => PlaybackPosition::Samples(
+                x + (settings.seek_time * self.sample_rate as f32) as usize,
+            ),
+        })
     }
 }

--- a/crates/core/src/data/streaming.rs
+++ b/crates/core/src/data/streaming.rs
@@ -52,17 +52,14 @@ impl<E: Send> With<SceneDialogSettings> for StreamingSoundData<E> {
     where
         Self: Sized,
     {
-        if settings.is_rewind {
-            let given = self.settings.start_position;
-            return self.start_position(match given {
-                PlaybackPosition::Seconds(x) => {
-                    PlaybackPosition::Seconds(x + settings.seek_time as f64)
-                }
-                PlaybackPosition::Samples(_) => {
-                    unreachable!("samples unit is not supported with streaming sound yet")
-                }
-            });
-        }
-        self
+        let given = self.settings.start_position;
+        self.start_position(match given {
+            PlaybackPosition::Seconds(x) => {
+                PlaybackPosition::Seconds(x + settings.seek_time as f64)
+            }
+            PlaybackPosition::Samples(_) => {
+                unreachable!("samples unit is not supported with streaming sound yet")
+            }
+        })
     }
 }


### PR DESCRIPTION
As of now, the lipsync must be set to a silent `.wem` in `voiceovermap.json`, apparently of the same duration as custom audio's used with audioware.