### PR TITLE
Note on Entity registration

### DIFF
--- a/book/pages/SPATIALIZATION.md
+++ b/book/pages/SPATIALIZATION.md
@@ -11,6 +11,10 @@ You must provide a `tag_name` which Audioware uses to track emitters internally.
 GameInstance.GetAudioSystemExt(game).RegisterEmitter(emitterID, n"MyMod");
 ```
 
+```admonish warning title="Lifecycle"
+When registering spatial emitters with Codeware, use `n"Entity/AfterAttach"` instead of [deprecated `n"Entity/Attached"`](https://github.com/psiberx/cp2077-codeware/blob/5e3b71757d6633d30363de0e0bb570a72df33f18/src/App/Callback/Controllers/EntityAttachHook.hpp#L18) which can cause issues with Audioware.
+```
+
 ```admonish warning title="Types"
 Audio emitter have to be positioned so they can only be [Entity](https://nativedb.red4ext.com/Entity) or classes inheriting from it like [GameObject](https://nativedb.red4ext.com/GameObject), devices, vehicles, NPCs, etc.
 ```


### PR DESCRIPTION
As reported by `CyanideX` during tests, it seems that using `Entity/Attached` to register spatial emitters sometimes cause issue with the messages queues:
```sh
[2026-01-14 13:07:38 UTC-08:00] [224472] plugin game loop is not initialized
```
> This is the same issue reported by [chin880810](https://www.nexusmods.com/cyberpunk2077/users/28738170) on Nexus.

This PR adds a note suggesting the use of `Entity/AfterAttach` instead.