### PR TITLE
Allow to enable/disable `Debug` files

### DIFF
--- a/crates/audioware/reds/Debug/CallbackExample.reds
+++ b/crates/audioware/reds/Debug/CallbackExample.reds
@@ -3,6 +3,7 @@ import Audioware.*
 public class AudioCallbackService extends ScriptableService {
     private let occlusions: ref<inkIntHashMap>;
     private cb func OnLoad() {
+        if !EnableAudiowareCallbackExample() { return; }
         FTLog(s"AudioCallbackService.OnLoad");
         let system = new AudioEventCallbackSystem();
         system.RegisterCallback(n"game_occlusion", this, n"OnOcclusion");
@@ -65,66 +66,5 @@ public class AudioCallbackService extends ScriptableService {
         } else {
             FTLog(s"AudioCallbackService.OnMetalCar class_name: \(NameToString(base.GetClassName()))");
         }
-    }
-}
-
-public class MyFireSystem extends ScriptableSystem {
-    // change for whichever weapon you're wielding
-    public let weaponEventName: CName = n"w_gun_lmg_power_ma70_fire_single";
-    private let fire: ref<AudioEventCallbackHandler>;
-    private let add: ref<AudioEventCallbackHandler>;
-    private let idle: ref<AudioEventCallbackHandler>;
-    private final func OnPlayerAttach(request: ref<PlayerAttachRequest>) -> Void {
-        let system = new AudioEventCallbackSystem();
-        if !IsDefined(this.add) {
-            this.add = system
-                .RegisterCallback(this.weaponEventName, this, n"OnFireSMG")
-                .AddTarget(EventTarget.ActionType(IntEnum<audioEventActionType>(Cast<Int32>(EnumValueFromName(n"audioEventActionType", n"AddContainerStreamingPrefetch")))))
-                .AddTarget(EventTarget.ActionType(IntEnum<audioEventActionType>(Cast<Int32>(EnumValueFromName(n"audioEventActionType", n"RemoveContainerStreamingPrefetch")))));
-        }
-        if !IsDefined(this.fire) {
-            this.fire = system
-                .RegisterCallback(this.weaponEventName, this, n"OnFireSMG")
-                .AddTarget(EmitterTarget.EmitterName(n"firearm_emitter"));
-        }
-        if !IsDefined(this.idle) {
-            this.idle = system
-                .RegisterCallback(n"idleStart", this, n"OnStopIdleStart")
-                .AddTarget(EventTarget.ActionType(audioEventActionType.StopSound));
-        }
-    }
-    public final func OnPlayerDetach(player: ref<PlayerPuppet>) -> Void {
-        if IsDefined(this.add) && this.add.IsRegistered() {
-            this.add.Unregister();
-            this.add = null;
-        }
-        if IsDefined(this.fire) && this.fire.IsRegistered() {
-            this.fire.Unregister();
-            this.fire = null;
-        }
-        if IsDefined(this.idle) && this.idle.IsRegistered() {
-            this.idle.Unregister();
-            this.idle = null;
-        }
-    }
-    private cb func OnFireSMG(event: ref<SoundEvent>) {
-        if event.IsA(n"Audioware.PlayEvent") {
-            let play = event as PlayEvent;
-            FTLog(s"MyFireSystem.OnFireSMG on entity: \(EntityID.ToDebugString(play.EntityID())) \(play.EntityID()), emitter name: \(NameToString(play.EmitterName()))");
-        }
-        else if event.IsA(n"Audioware.AddContainerStreamingPrefetchEvent") {
-            let prefetch = event as AddContainerStreamingPrefetchEvent;
-            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName())) entity: \(EntityID.ToDebugString(prefetch.EntityID())), wwise_id: \(prefetch.WwiseID())");
-        }
-        else if event.IsA(n"Audioware.RemoveContainerStreamingPrefetchEvent") {
-            let prefetch = event as RemoveContainerStreamingPrefetchEvent;
-            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName())) entity: \(EntityID.ToDebugString(prefetch.EntityID())), wwise_id: \(prefetch.WwiseID())");
-        }
-        else {
-            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName()))");
-        }
-    }
-    private cb func OnStopIdleStart(event: ref<StopSoundEvent>) {
-        FTLog(s"MyFireSystem.OnStopIdleStart => event_name: \(NameToString(event.SoundName())), entity_id: \(EntityID.ToDebugString(event.EntityID())), fade_out: \(event.FadeOut())");
     }
 }

--- a/crates/audioware/reds/Debug/ChangeCombatMusic.reds
+++ b/crates/audioware/reds/Debug/ChangeCombatMusic.reds
@@ -12,6 +12,7 @@ public class ChangeCombatMusic extends ScriptableSystem {
     private let volume: Float = 1.;
     private let playing: CName = n"None";
     private final func OnPlayerAttach(request: ref<PlayerAttachRequest>) -> Void {
+        if !EnableAudiowareChangeCombatMusic() { return; }
         let manager = new AudioEventManager();
         // mute vanilla combat music
         manager.Mute(n"gmp_ui_prevention_player_commit_crime");
@@ -101,6 +102,7 @@ public class ChangeCombatMusic extends ScriptableSystem {
 @wrapMethod(PreventionSystem)
 private final func OnHeatChanged(previousHeat: EPreventionHeatStage) -> Void {
     wrappedMethod(previousHeat);
+    if !EnableAudiowareChangeCombatMusic() { return; }
     if NotEquals(previousHeat, this.m_heatStage) {
         ChangeCombatMusic
             .GetInstance(this.GetGame())
@@ -111,6 +113,8 @@ private final func OnHeatChanged(previousHeat: EPreventionHeatStage) -> Void {
 // notify how many agents can or cannot see player
 @wrapMethod(PreventionSystem)
 private final func HasViewersChanged(currentViewerState: Bool) -> Void {
+    wrappedMethod(currentViewerState);
+    if !EnableAudiowareChangeCombatMusic() { return; }
     if NotEquals(currentViewerState, this.m_hasViewers) {
         ChangeCombatMusic
             .GetInstance(this.GetGame())
@@ -121,6 +125,7 @@ private final func HasViewersChanged(currentViewerState: Bool) -> Void {
 // notify when player starts sprinting or crouching
 @wrapMethod(PlayerPuppet)
 protected cb func OnLocomotionStateChanged(newState: Int32) -> Bool {
+    if !EnableAudiowareChangeCombatMusic() { return wrappedMethod(newState); }
     let previous = this.m_locomotionState;
 
     let out = wrappedMethod(newState);
@@ -137,6 +142,7 @@ protected cb func OnLocomotionStateChanged(newState: Int32) -> Bool {
 // notify when player is about to die
 @wrapMethod(PlayerPuppet)
 protected cb func OnDeath(evt: ref<gameDeathEvent>) -> Bool {
+    if !EnableAudiowareChangeCombatMusic() { return wrappedMethod(evt); }
     ChangeCombatMusic
         .GetInstance(this.GetGame())
         .OnDeath();

--- a/crates/audioware/reds/Debug/ChangeIntro.reds
+++ b/crates/audioware/reds/Debug/ChangeIntro.reds
@@ -4,6 +4,7 @@ public class ChangeIntroService extends ScriptableService {
     private let replaced: Bool;
     private let handler: ref<AudioEventCallbackHandler>;
     private cb func OnLoad() {
+        if !EnableAudiowareChangeIntro() { return; }
         FTLog(s"ChangeIntroService.OnLoad");
         let system = new AudioEventCallbackSystem();
         this.handler = system

--- a/crates/audioware/reds/Debug/ChangeMenuSounds.reds
+++ b/crates/audioware/reds/Debug/ChangeMenuSounds.reds
@@ -4,6 +4,7 @@ public class ChangeMenuSounds extends ScriptableService {
     private let mainMenuMusic: ref<DynamicSoundEvent>;
     private let isPreGame: Bool = false;
     private cb func OnLoad() {
+        if !EnableAudiowareChangeMenuSounds() { return; }
         let manager = new AudioEventManager();
         // mute main menu ambience music (once clicked Press to Start)
         manager.Mute(n"mus_game_menus_00_title_screen_START");

--- a/crates/audioware/reds/Debug/Constants.reds
+++ b/crates/audioware/reds/Debug/Constants.reds
@@ -1,0 +1,5 @@
+public func EnableAudiowareChangeIntro() -> Bool       = false;
+public func EnableAudiowareChangeMenuSounds() -> Bool  = false;
+public func EnableAudiowareCallbackExample() -> Bool   = false;
+public func EnableAudiowareFireSystemExample() -> Bool = false;
+public func EnableAudiowareChangeCombatMusic() -> Bool = false;

--- a/crates/audioware/reds/Debug/FireSystemExample.reds
+++ b/crates/audioware/reds/Debug/FireSystemExample.reds
@@ -1,0 +1,64 @@
+import Audioware.*
+
+public class MyFireSystem extends ScriptableSystem {
+    // change for whichever weapon you're wielding
+    public let weaponEventName: CName = n"w_gun_lmg_power_ma70_fire_single";
+    private let fire: ref<AudioEventCallbackHandler>;
+    private let add: ref<AudioEventCallbackHandler>;
+    private let idle: ref<AudioEventCallbackHandler>;
+    private final func OnPlayerAttach(request: ref<PlayerAttachRequest>) -> Void {
+        if !EnableAudiowareFireSystemExample() { return; }
+        let system = new AudioEventCallbackSystem();
+        if !IsDefined(this.add) {
+            this.add = system
+                .RegisterCallback(this.weaponEventName, this, n"OnFireSMG")
+                .AddTarget(EventTarget.ActionType(IntEnum<audioEventActionType>(Cast<Int32>(EnumValueFromName(n"audioEventActionType", n"AddContainerStreamingPrefetch")))))
+                .AddTarget(EventTarget.ActionType(IntEnum<audioEventActionType>(Cast<Int32>(EnumValueFromName(n"audioEventActionType", n"RemoveContainerStreamingPrefetch")))));
+        }
+        if !IsDefined(this.fire) {
+            this.fire = system
+                .RegisterCallback(this.weaponEventName, this, n"OnFireSMG")
+                .AddTarget(EmitterTarget.EmitterName(n"firearm_emitter"));
+        }
+        if !IsDefined(this.idle) {
+            this.idle = system
+                .RegisterCallback(n"idleStart", this, n"OnStopIdleStart")
+                .AddTarget(EventTarget.ActionType(audioEventActionType.StopSound));
+        }
+    }
+    public final func OnPlayerDetach(player: ref<PlayerPuppet>) -> Void {
+        if !EnableAudiowareFireSystemExample() { return; }
+        if IsDefined(this.add) && this.add.IsRegistered() {
+            this.add.Unregister();
+            this.add = null;
+        }
+        if IsDefined(this.fire) && this.fire.IsRegistered() {
+            this.fire.Unregister();
+            this.fire = null;
+        }
+        if IsDefined(this.idle) && this.idle.IsRegistered() {
+            this.idle.Unregister();
+            this.idle = null;
+        }
+    }
+    private cb func OnFireSMG(event: ref<SoundEvent>) {
+        if event.IsA(n"Audioware.PlayEvent") {
+            let play = event as PlayEvent;
+            FTLog(s"MyFireSystem.OnFireSMG on entity: \(EntityID.ToDebugString(play.EntityID())) \(play.EntityID()), emitter name: \(NameToString(play.EmitterName()))");
+        }
+        else if event.IsA(n"Audioware.AddContainerStreamingPrefetchEvent") {
+            let prefetch = event as AddContainerStreamingPrefetchEvent;
+            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName())) entity: \(EntityID.ToDebugString(prefetch.EntityID())), wwise_id: \(prefetch.WwiseID())");
+        }
+        else if event.IsA(n"Audioware.RemoveContainerStreamingPrefetchEvent") {
+            let prefetch = event as RemoveContainerStreamingPrefetchEvent;
+            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName())) entity: \(EntityID.ToDebugString(prefetch.EntityID())), wwise_id: \(prefetch.WwiseID())");
+        }
+        else {
+            FTLog(s"MyFireSystem.OnFireSMG \(NameToString(event.GetClassName()))");
+        }
+    }
+    private cb func OnStopIdleStart(event: ref<StopSoundEvent>) {
+        FTLog(s"MyFireSystem.OnStopIdleStart => event_name: \(NameToString(event.SoundName())), entity_id: \(EntityID.ToDebugString(event.EntityID())), fade_out: \(event.FadeOut())");
+    }
+}


### PR DESCRIPTION
Add `Constants.reds` to quickly enable/disable `Debug` files.

Git command to track/untrack file in git:
```sh
# track back
git update-index --no-skip-worktree .\crates\audioware\reds\Debug\Constants.reds
# untrack
git update-index --skip-worktree .\crates\audioware\reds\Debug\Constants.reds
```