### PR TITLE
Fix panning validation bounds and default center initialization

### DIFF
--- a/crates/audioware/reds/Settings.reds
+++ b/crates/audioware/reds/Settings.reds
@@ -11,7 +11,7 @@ public class AudioSettingsExt {
     public let loop: Bool = false;
     public let volume: Float = 1.;
     public let fadeIn: ref<Tween>;
-    public let panning: Float = 0.5;
+    public let panning: Float = 0.0;
     public let playbackRate: Float = 1.;
     public let affectedByTimeDilation: Bool = true;
 }

--- a/crates/audioware/src/abi/types.rs
+++ b/crates/audioware/src/abi/types.rs
@@ -58,7 +58,7 @@ impl Default for AudioSettingsExt {
             r#loop: false,
             volume: 1.,
             fade_in: Ref::default(),
-            panning: 0.5,
+            panning: 0.0,
             playback_rate: 1.,
             affected_by_time_dilation: true,
         }

--- a/crates/manifest/src/de/setting.rs
+++ b/crates/manifest/src/de/setting.rs
@@ -282,11 +282,11 @@ impl Validate for Settings {
     fn validate(&self) -> Result<(), Vec<ValidationError>> {
         let mut errors: Vec<_> = vec![];
         if let Some(panning) = self.panning
-            && !(0.0..=1.0).contains(&panning)
+            && !(-1.0..=1.0).contains(&panning)
         {
             errors.push(ValidationError {
                 which: "panning",
-                why: "must be a value between 0.0 and 1.0 (inclusive)",
+                why: "must be a value between -1.0 and 1.0 (inclusive)",
             });
         }
         if let Some(volume) = self.volume


### PR DESCRIPTION
This resolves an issue where left-channel audio panning is completely silent, and default sound events play panned to the right.
Kira uses a panning range of `-1.0` (fully left) to `1.0` (fully right), where `0.0` is center.
However, Audioware's manifest settings validator (`crates/manifest/src/de/setting.rs`) was validating that panning fell within `0.0..=1.0`.

Changes made:
`crates/manifest/src/de/setting.rs`
Updated the validation range from `0.0..=1.0` to `-1.0..=1.0` to permit negative (left channel) panning
`crates/audioware/src/abi/types.rs`
Updated `AudioSettingsExt::default()` to initialize `panning` to `0.0` 
`crates/audioware/reds/Settings.reds`
Updated `panning` default class property to `0.0` to match the native changes.